### PR TITLE
Correct CoreCount on non-Pi devices

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -19,7 +19,8 @@ PADDVersion="2.1.0"
 today=$(date +%Y%m%d)
 
 # CORES
-coreCount=$(grep -c 'model name' /proc/cpuinfo)
+declare -i coreCount=1
+coreCount=$(cat /sys/devices/system/cpu/kernel_max 2> /dev/null)+1
 
 # COLORS
 blackText=$(tput setaf 0)   # Black


### PR DESCRIPTION
$CoreCount assumes a certain format to /proc/cpuinfo - this grabs the information from /sys/dev/cpu instead.
Tested on my Pine64