### PR TITLE
Updated GetVersionInformation()#padd version check

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -490,7 +490,7 @@ GetVersionInformation() {
     fi
 
     # PADD version information...
-    padd_version_latest=$(curl -sI https://github.com/jpmck/PADD/releases/latest | grep 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n[:alpha:]')
+    padd_version_latest=$(curl -sI https://github.com/jpmck/PADD/releases/latest | grep -i 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n[:alpha:]')
 
     # is PADD up-to-date?
     if [[ "${padd_version}" != "${padd_version_latest}" ]]; then


### PR DESCRIPTION
The "location" header is lower case and the check is failing to retreieve any data from github.  Making the grep case-insensative resolves this issue.