### PR TITLE
Add new "Tiny" screen size for Adafruit 2.8 screen

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -908,7 +908,7 @@ SizeChecker(){
   elif [[ "$console_width" -lt "40" || "$console_height" -lt "18" ]]; then
     padd_size="micro"
   # Below Tiny. Gives you Mini.
-  elif [[ "$console_width" -lt "50" || "$console_height" -lt "20" ]]; then
+  elif [[ "$console_width" -lt "53" || "$console_height" -lt "20" ]]; then
       padd_size="mini"
   # Below Slim. Gives you Tiny.    
   elif [[ "$console_width" -lt "60" || "$console_height" -lt "21" ]]; then

--- a/padd.sh
+++ b/padd.sh
@@ -84,6 +84,15 @@ mega_status_ftl_down="${check_box_info} FTLDNS service is not running."
 mega_status_dns_down="${check_box_bad} Pi-hole's DNS server is off!"
 mega_status_unknown="${check_box_question} Unable to determine Pi-hole status."
 
+# TINY STATUS
+tiny_status_ok="${check_box_good} System is healthy."
+tiny_status_update="${check_box_info} Updates are available."
+tiny_status_hot="${check_box_bad} System is hot!"
+tiny_status_off="${check_box_bad} Pi-hole is offline"
+tiny_status_ftl_down="${check_box_info} FTL is down!"
+tiny_status_dns_down="${check_box_bad} DNS is off!"
+tiny_status_unknown="${check_box_question} Status unknown!"
+
 # Text only "logos"
 padd_text="${green_text}${bold_text}PADD${reset_text}"
 padd_text_retro="${bold_text}${red_text}P${yellow_text}A${green_text}D${blue_text}D${reset_text}${reset_text}"
@@ -187,6 +196,16 @@ GetSummaryInformation() {
     if [ ${#top_blocked} -gt 30 ]; then
       top_blocked=$(echo "$top_blocked" | cut -c1-27)"..."
     fi
+  elif [ "$1" = "tiny" ]; then
+    ads_blocked_bar=$(BarGenerator "$ads_percentage_today" 30 "color")
+
+    if [ ${#latest_blocked} -gt 39 ]; then
+      latest_blocked=$(echo "$latest_blocked" | cut -c1-39)"..."
+    fi
+
+    if [ ${#top_blocked} -gt 39 ]; then
+      top_blocked=$(echo "$top_blocked" | cut -c1-39)"..."
+    fi     
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     ads_blocked_bar=$(BarGenerator "$ads_percentage_today" 40 "color")
   else
@@ -250,6 +269,9 @@ GetSystemInformation() {
   if [ "$1" = "mini" ]; then
     cpu_bar=$(BarGenerator "${cpu_percent}" 20)
     memory_bar=$(BarGenerator "${memory_percent}" 20)
+  elif [ "$1" = "tiny" ]; then
+    cpu_bar=$(BarGenerator "${cpu_percent}" 8)
+    memory_bar=$(BarGenerator "${memory_percent}" 8)   
   else
     cpu_bar=$(BarGenerator "${cpu_percent}" 10)
     memory_bar=$(BarGenerator "${memory_percent}" 10)
@@ -377,6 +399,7 @@ GetPiholeInformation() {
     pihole_check_box=${check_box_bad}
     pico_status=${pico_status_off}
     mini_status_=${mini_status_off}
+    tiny_status_=${tiny_status_off}   
     full_status_=${full_status_off}
     mega_status=${mega_status_off}
   elif [[ ${pihole_web_status} == -1 ]]; then
@@ -385,6 +408,7 @@ GetPiholeInformation() {
     pihole_check_box=${check_box_bad}
     pico_status=${pico_status_dns_down}
     mini_status_=${mini_status_dns_down}
+    tiny_status_=${tiny_status_dns_down} 
     full_status_=${full_status_dns_down}
     mega_status=${mega_status_dns_down}
   else
@@ -393,6 +417,7 @@ GetPiholeInformation() {
     pihole_check_box=${check_box_question}
     pico_status=${pico_status_unknown}
     mini_status_=${mini_status_unknown}
+    tiny_status_=${tiny_status_unknown}  
     full_status_=${full_status_unknown}
     mega_status=${mega_status_unknown}
   fi
@@ -406,6 +431,7 @@ GetPiholeInformation() {
     ftl_check_box=${check_box_info}
     pico_status=${pico_status_ftl_down}
     mini_status_=${mini_status_ftl_down}
+    tiny_status_=${tiny_status_ftl_down}    
     full_status_=${full_status_ftl_down}
     mega_status=${mega_status_ftl_down}
   else
@@ -440,7 +466,6 @@ GetVersionInformation() {
     core_version_latest=${core_versions[5]//)}
 
     if [[ "${core_version_latest}" == "ERROR" ]]; then
-      core_version_latest=${core_version}
       core_version_heatmap=${yellow_text}
     else
       core_version_latest=$(echo "${core_version_latest}" | tr -d '\r\n[:alpha:]')
@@ -458,7 +483,6 @@ GetVersionInformation() {
     web_version=$(echo "${web_versions[3]}" | tr -d '\r\n[:alpha:]')
     web_version_latest=${web_versions[5]//)}
     if [[ "${web_version_latest}" == "ERROR" ]]; then
-      web_version_latest=${web_version}
       web_version_heatmap=${yellow_text}
     else
       web_version_latest=$(echo "${web_version_latest}" | tr -d '\r\n[:alpha:]')
@@ -476,7 +500,6 @@ GetVersionInformation() {
     ftl_version=$(echo "${ftl_versions[3]}" | tr -d '\r\n[:alpha:]')
     ftl_version_latest=${ftl_versions[5]//)}
     if [[ "${ftl_version_latest}" == "ERROR" ]]; then
-      ftl_version_latest=${ftl_version}
       ftl_version_heatmap=${yellow_text}
     else
       ftl_version_latest=$(echo "${ftl_version_latest}" | tr -d '\r\n[:alpha:]')
@@ -493,12 +516,16 @@ GetVersionInformation() {
     padd_version_latest=$(json_extract tag_name "$(curl -s 'https://api.github.com/repos/pi-hole/PADD/releases/latest' 2> /dev/null)")
 
     # is PADD up-to-date?
-    if [[ "${padd_version}" != "${padd_version_latest}" ]]; then
-      padd_out_of_date_flag="true"
-      padd_version_heatmap=${red_text}
-    else
-      padd_version_heatmap=${green_text}
-    fi
+    if [[ "${padd_version_latest}" == "" ]]; then
+      padd_version_heatmap=${yellow_text}
+    else   
+      if [[ "${padd_version}" != "${padd_version_latest}" ]]; then
+        padd_out_of_date_flag="true"
+        padd_version_heatmap=${red_text}
+      else
+        padd_version_heatmap=${green_text}
+      fi
+    fi    
 
     # was any portion of Pi-hole out-of-date?
     # yes, pi-hole is out of date
@@ -508,6 +535,7 @@ GetVersionInformation() {
       version_check_box=${check_box_bad}
       pico_status=${pico_status_update}
       mini_status_=${mini_status_update}
+      tiny_status_=${tiny_status_update} 
       full_status_=${full_status_update}
       mega_status=${mega_status_update}
     else
@@ -518,6 +546,7 @@ GetVersionInformation() {
         version_check_box=${check_box_bad}
         pico_status=${pico_status_update}
         mini_status_=${mini_status_update}
+        tiny_status_=${tiny_status_update}        
         full_status_=${full_status_update}
         mega_status=${mega_status_update}
       # else, everything is good!
@@ -527,6 +556,7 @@ GetVersionInformation() {
         version_check_box=${check_box_good}
         pico_status=${pico_status_ok}
         mini_status_=${mini_status_ok}
+        tiny_status_=${tiny_status_ok}         
         full_status_=${full_status_ok}
         mega_status=${mega_status_ok}
       fi
@@ -536,15 +566,19 @@ GetVersionInformation() {
     echo "last_check=${today}" > ./piHoleVersion
     {
       echo "core_version=$core_version"
+      echo "core_version_latest=$core_version_latest"     
       echo "core_version_heatmap=$core_version_heatmap"
 
       echo "web_version=$web_version"
+      echo "web_version_latest=$web_version_latest"         
       echo "web_version_heatmap=$web_version_heatmap"
 
       echo "ftl_version=$ftl_version"
+      echo "ftl_version_latest=$ftl_version_latest"       
       echo "ftl_version_heatmap=$ftl_version_heatmap"
 
       echo "padd_version=$padd_version"
+      echo "padd_version_latest=$padd_version_latest"       
       echo "padd_version_heatmap=$padd_version_heatmap"
 
       echo "version_status=\"$version_status\""
@@ -553,6 +587,7 @@ GetVersionInformation() {
 
       echo "pico_status=\"$pico_status\""
       echo "mini_status_=\"$mini_status_\""
+      echo "tiny_status_=\"$tiny_status_\""        
       echo "full_status_=\"$full_status_\""
     } >> ./piHoleVersion
 
@@ -588,6 +623,9 @@ PrintLogo() {
   elif [ "$1" = "mini" ]; then
     CleanEcho "${padd_text}${dim_text}mini${reset_text}  ${mini_status_}"
     CleanEcho ""
+  elif [ "$1" = "tiny" ]; then
+    CleanEcho "${bold_text} ${reset_text}${padd_text}${dim_text}tiny ${reset_text}Pi-hole® ${core_version_heatmap}v${core_version}${reset_text}, Web ${web_version_heatmap}v${web_version}${reset_text}, FTL ${ftl_version_heatmap}v${ftl_version}${reset_text}"
+    CleanPrintf "          PADD ${padd_version_heatmap}${padd_version}${reset_text} ${tiny_status_}${reset_text}\e[0K\\n"    
   elif [ "$1" = "slim" ]; then
     CleanEcho "${padd_text}${dim_text}slim${reset_text}   ${full_status_}"
     CleanEcho ""
@@ -632,6 +670,14 @@ PrintNetworkInformation() {
     if [[ "${DHCP_ACTIVE}" == "true" ]]; then
       CleanPrintf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}\e[0K\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
     fi
+  elif [ "$1" = "tiny" ]; then
+    CleanEcho "${bold_text} NETWORK ===========================================${reset_text}"
+    CleanPrintf " %-10s%-15s%-6s%-19s\e[0K\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "DNS:" "${dns_information}"
+
+    if [[ "${DHCP_ACTIVE}" == "true" ]]; then
+      CleanPrintf " %-10s${dhcp_heatmap}%-14s${reset_text} %-6s${dhcp_ipv6_heatmap}%-10s${reset_text}\e[0K\\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
+    fi        
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}NETWORK ===================================================${reset_text}"
     CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "Hostname:" "${full_hostname}" "IPv4:" "${IPV4_ADDRESS}"
@@ -669,6 +715,9 @@ PrintPiholeInformation() {
   elif [ "$1" = "mini" ]; then
     CleanEcho "${bold_text}PI-HOLE ================================${reset_text}"
     CleanPrintf " %-9s${pihole_heatmap}%-10s${reset_text} %-9s${ftl_heatmap}%-10s${reset_text}\e[0K\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
+  elif [ "$1" = "tiny" ]; then
+    CleanEcho "${bold_text} PI-HOLE ===========================================${reset_text}"
+    CleanPrintf " %-10s${pihole_heatmap}%-14s${reset_text} %-7s${ftl_heatmap}%-10s${reset_text}\e[0K\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"    
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}PI-HOLE ===================================================${reset_text}"
     CleanPrintf " %-10s${pihole_heatmap}%-19s${reset_text} %-10s${ftl_heatmap}%-19s${reset_text}\e[0K\\n" "Status:" "${pihole_status}" "FTL:" "${ftl_status}"
@@ -678,7 +727,7 @@ PrintPiholeInformation() {
 }
 
 PrintPiholeStats() {
-  # are we on a tiny screen?
+  # are we on a reduced screen size?
   if [ "$1" = "pico" ]; then
     CleanEcho "${bold_text}PI-HOLE ============${reset_text}"
     CleanEcho " [${ads_blocked_bar}] ${ads_percentage_today}%"
@@ -700,6 +749,15 @@ PrintPiholeStats() {
     if [[ "${DHCP_ACTIVE}" != "true" ]]; then
       CleanPrintf " %-9s%-29s\\n" "Top Ad:" "${top_blocked}"
     fi
+  elif [ "$1" = "tiny" ]; then
+    CleanEcho "${bold_text} STATS =============================================${reset_text}"
+    CleanPrintf " %-10s%-29s\e[0K\\n" "Blckng:" "${domains_being_blocked} domains"
+    CleanPrintf " %-10s[%-30s] %-5s\e[0K\\n" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Piholed:" "${ads_blocked_today} out of ${dns_queries_today}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Latest:" "${latest_blocked}"
+    CleanPrintf " %-10s%-39s\e[0K\\n" "Top Ad:" "${top_blocked}"
+    CleanPrintf " ${bold_text}%-4s${reset_text}%-6s%-9s %-9s%-6s %-10s%-6s\e[0K\\n" "FTL " "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
+    CleanPrintf " %-10s%-42s\e[0K\\n" "DNSCache:" "${cache_inserts} ins, ${cache_deletes} del, ${cache_size} tot"     
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}STATS =====================================================${reset_text}"
     CleanPrintf " %-10s%-49s\e[0K\\n" "Blocking:" "${domains_being_blocked} domains"
@@ -743,6 +801,12 @@ PrintSystemInformation() {
     CleanPrintf " %-9s%-29s\\n" "Uptime:" "${system_uptime}"
     CleanEcho " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
     echo -ne "${ceol}Memory:  [${memory_heatmap}${memory_bar}${reset_text}] ${memory_percent}%"
+  elif [ "$1" = "tiny" ]; then
+    CleanEcho "${bold_text} SYSTEM ============================================${reset_text}"
+    CleanPrintf " %-10s%-29s\e[0K\\n" "Uptime:" "${system_uptime}"
+    CleanPrintf " %-10s${temp_heatmap}%-19s${reset_text}%-6s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}\e[0K\\n" "CPU Temp:" "${temperature}" "Load:" "${cpu_load[0]}" "${cpu_load[1]}" "${cpu_load[2]}"
+    # Memory and CPU bar
+    CleanPrintf " %-10s[${memory_heatmap}%-8s${reset_text}] %-6s %-5s[${cpu_load_1_heatmap}%-8s${reset_text}] %-5s" "Memory:" "${memory_bar}" "${memory_percent}%" "CPU:" "${cpu_bar}" "${cpu_percent}%"     
   # else we're not
   elif [[ "$1" = "regular" || "$1" = "slim" ]]; then
     CleanEcho "${bold_text}SYSTEM ====================================================${reset_text}"
@@ -843,9 +907,12 @@ SizeChecker(){
   # Below Mini. Gives you Micro.
   elif [[ "$console_width" -lt "40" || "$console_height" -lt "18" ]]; then
     padd_size="micro"
-  # Below Slim. Gives you Mini.
-  elif [[ "$console_width" -lt "60" || "$console_height" -lt "20" ]]; then
-    padd_size="mini"
+  # Below Tiny. Gives you Mini.
+  elif [[ "$console_width" -lt "50" || "$console_height" -lt "20" ]]; then
+      padd_size="mini"
+  # Below Slim. Gives you Tiny.    
+  elif [[ "$console_width" -lt "60" || "$console_height" -lt "21" ]]; then
+      padd_size="tiny"    
   # Below Regular. Gives you Slim.
   elif [[ "$console_width" -lt "80" || "$console_height" -lt "26" ]]; then
     if [[ "$console_height" -lt "22" ]]; then
@@ -886,7 +953,7 @@ CheckConnectivity() {
       while [ $inner_wait_timer -gt 0 ]; do
         if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
           echo -ne "Attempt #${connection_attempts} failed...\\r"
-        elif [ "$1" = "mini" ]; then
+        elif [ "$1" = "mini" ] || [ "$1" = "tiny" ]; then
           echo -ne "- Attempt ${connection_attempts} failed, wait ${inner_wait_timer}  \\r"
         else
           echo -ne "  - Attempt ${connection_attempts} failed... waiting ${inner_wait_timer} seconds...  \\r"
@@ -905,7 +972,7 @@ CheckConnectivity() {
   if [ "$connectivity" = "false" ]; then
     if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
       echo "Check failed..."
-    elif [ "$1" = "mini" ]; then
+    elif [ "$1" = "mini" ] || [ "$1" = "tiny" ]; then
       echo "- Connectivity check failed."
     else
       echo "  - Connectivity check failed..."
@@ -913,7 +980,7 @@ CheckConnectivity() {
   else
     if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
       echo "Check passed..."
-    elif [ "$1" = "mini" ]; then
+    elif [ "$1" = "mini" ] || [ "$1" = "tiny" ]; then
       echo "- Connectivity check passed."
     else
       echo "  - Connectivity check passed..."
@@ -1019,7 +1086,11 @@ StartupRoutine(){
     echo -e "${padd_logo_retro_1}"
     echo -e "${padd_logo_retro_2}Pi-hole® Ad Detection Display"
     echo -e "${padd_logo_retro_3}A client for Pi-hole\\n"
-    echo "START UP ==================================================="
+    if [ "$1" = "tiny" ]; then
+      echo "START UP =========================================="
+    else
+      echo "START UP ==================================================="
+    fi
 
     echo -e "- Checking internet connection..."
     CheckConnectivity "$1"
@@ -1091,6 +1162,7 @@ NormalPADD() {
 
     pico_status=${pico_status_ok}
     mini_status_=${mini_status_ok}
+    tiny_status_=${tiny_status_ok}   
 
     # Start getting our information
     GetVersionInformation ${padd_size}


### PR DESCRIPTION
1. Add new "tiny" screen size for Adafruit 2.8 screen.
2. Include logic to show PADD version in orange if the process fails to retrieve the latest version.
3. Update the version log file to include the current version and the retrieved latest version.