### PR TITLE
Fix incorrect bar size when first loading tiny

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -1111,14 +1111,14 @@ StartupRoutine(){
 
     # Get our information for the first time
     echo "- Gathering system information..."
-    GetSystemInformation
+    GetSystemInformation "$1"
     echo "- Gathering Pi-hole information..."
-    GetSummaryInformation
-    GetPiholeInformation
+    GetSummaryInformation "$1"
+    GetPiholeInformation "$1"
     echo "- Gathering network information..."
-    GetNetworkInformation
+    GetNetworkInformation "$1"
     echo "- Gathering version information..."
-    GetVersionInformation
+    GetVersionInformation "$1"
     echo "  - Pi-hole Core v$core_version"
     echo "  - Web Admin v$web_version"
     echo "  - FTL v$ftl_version"


### PR DESCRIPTION
- Add passing the size for Get*Information calls during startup to fix
incorrect bar sizes during initial load

- Should be more compatible with any future additional sizes

Currently, the tiny size will load a 10 segment bar until the first refresh since the initial load does not pass a size argument like for pico, nano, mico, and mini.