### PR TITLE
Consider REV_SERVER for Conditonal Forwarding; append domain to hostname only when DHCP is enabled.

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -17,7 +17,7 @@ LC_NUMERIC=C
 ############################################ VARIABLES #############################################
 
 # VERSION
-padd_version="v3.3.1"
+padd_version="v3.4"
 
 # DATE
 today=$(date +%Y%m%d)
@@ -284,17 +284,16 @@ GetNetworkInformation() {
   pi_hostname=$(hostname)
   pi_gateway=$(ip r | grep 'default' | awk '{print $3}')
 
+  full_hostname=${pi_hostname}
   # does the Pi-hole have a domain set?
-  if [ -z ${PIHOLE_DOMAIN+x} ]; then
-    full_hostname=${pi_hostname}
-  else
-    count=${pi_hostname}"."${PIHOLE_DOMAIN}
-    count=${#count}
-
-    if [ "${count}" -lt "18" ]; then
-      full_hostname=${pi_hostname}"."${PIHOLE_DOMAIN}
-    else
-      full_hostname=${pi_hostname}
+  if ! [ -z ${PIHOLE_DOMAIN+x} ]; then
+    # is Pi-hole acting as DHCP server?
+    if [[ "${DHCP_ACTIVE}" == "true" ]]; then
+      count=${pi_hostname}"."${PIHOLE_DOMAIN}
+      count=${#count}
+      if [ "${count}" -lt "18" ]; then
+        full_hostname=${pi_hostname}"."${PIHOLE_DOMAIN}
+      fi
     fi
   fi
 
@@ -374,7 +373,7 @@ GetNetworkInformation() {
   fi
 
   # Conditional forwarding
-  if [[ "${CONDITIONAL_FORWARDING}" == "true" ]]; then
+  if [[ "${CONDITIONAL_FORWARDING}" == "true" ]] || [[ "${REV_SERVER}" == "true" ]]; then
     conditional_forwarding_status="Enabled"
     conditional_forwarding_heatmap=${green_text}
     conditional_forwarding_check_box=${check_box_good}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).
---

Conditional Forwarding:
Pi-hole 5 introduced REV_SERVER for use in setupVars.conf for improved readability.
Currently, PADD only tests for the older CONDITIONAL_FORWARDING.
Probably CONDITIONAL_FORWARDING may be removed some time in the future.

For the time being, suggested implementation tests for both.

Hostname:
The current implementation expands hostname by domain as found in setupVars.conf if its not excessively long (e.g. to read raspberrypi.lan).
However, this is less likely to be true if Pi-hole is not configured as DHCP server, as the router's domain may differ.

Suggested implementation considers expansion only if Pi-hole is acting as DHCP server.

**What documentation changes (if any) are needed to support this PR?:**
None.
