### PR TITLE
Improve CPU temperature display on machines with no reported CPU temp

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -229,7 +229,10 @@ GetSystemInformation() {
   fi
 
   # Convert CPU temperature to correct unit
-  if [ "${TEMPERATUREUNIT}" == "F" ]; then
+  # if CPU temp is 0, this indicates unreadable temp and/or PADD is running on a VM
+  if [ ${cpu} == 0 ]; then
+    temperature="Unknown"
+  elif [ "${TEMPERATUREUNIT}" == "F" ]; then
     temperature="$(printf %.1f "$(echo "${cpu}" | awk '{print $1 * 9 / 5000 + 32}')")°F"
   elif [ "${TEMPERATUREUNIT}" == "K" ]; then
     temperature="$(printf %.1f "$(echo "${cpu}" | awk '{print $1 / 1000 + 273.15}')")°K"
@@ -257,6 +260,8 @@ GetSystemInformation() {
     temp_heatmap=${magenta_text}
   elif [ ${cpu} -gt 60000 ]; then
     temp_heatmap=${blue_text}
+  elif [ ${cpu} == 0]; then
+    temp_heatmap=${white_text}
   else
     temp_heatmap=${cyan_text}
   fi

--- a/padd.sh
+++ b/padd.sh
@@ -260,7 +260,7 @@ GetSystemInformation() {
     temp_heatmap=${magenta_text}
   elif [ ${cpu} -gt 60000 ]; then
     temp_heatmap=${blue_text}
-  elif [ ${cpu} == 0]; then
+  elif [ ${cpu} == 0 ]; then
     temp_heatmap=${white_text}
   else
     temp_heatmap=${cyan_text}

--- a/padd.sh
+++ b/padd.sh
@@ -231,7 +231,7 @@ GetSystemInformation() {
   # Convert CPU temperature to correct unit
   # if CPU temp is 0, this indicates unreadable temp and/or PADD is running on a VM
   if [ ${cpu} == 0 ]; then
-    temperature="Unknown"
+    temperature="Unknown  "
   elif [ "${TEMPERATUREUNIT}" == "F" ]; then
     temperature="$(printf %.1f "$(echo "${cpu}" | awk '{print $1 * 9 / 5000 + 32}')")°F"
   elif [ "${TEMPERATUREUNIT}" == "K" ]; then


### PR DESCRIPTION
**What does this PR aim to accomplish?:**
For cases where PADD is installed on a VM or machine where the CPU temperature is not readable, the interface used to show 0 (or 32F) in cyan text. Now, in this case, the interface will display "Unknown" in white text. This addresses issue #137 

**How does this PR accomplish the above?:**
Add 2 if statements to the temp and color parts of GetSystemInformation() that check if ${cpu} is equal to 0 (which is the default value when /sys/class/thermal/thermal_zone0/temp does not return) and return the appropriate text/color.

**What documentation changes (if any) are needed to support this PR?:**
I don't believe any documentation changes are necessary.

---
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

This commit was made as part of my [Hacktoberfest](https://hacktoberfest.digitalocean.com/) contributions. If it's helpful, a `hacktoberfest-accepted` label from a maintainer would be appreciated 🎃 