### PR TITLE
update status of mega screen size

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -17,7 +17,7 @@ LC_NUMERIC=C
 ############################################ VARIABLES #############################################
 
 # VERSION
-padd_version="v3.5.1"
+padd_version="v3.6"
 
 # DATE
 today=$(date +%Y%m%d)

--- a/padd.sh
+++ b/padd.sh
@@ -17,7 +17,7 @@ LC_NUMERIC=C
 ############################################ VARIABLES #############################################
 
 # VERSION
-padd_version="v3.4"
+padd_version="v3.4.1"
 
 # DATE
 today=$(date +%Y%m%d)

--- a/padd.sh
+++ b/padd.sh
@@ -17,7 +17,7 @@ LC_NUMERIC=C
 ############################################ VARIABLES #############################################
 
 # VERSION
-padd_version="v3.4.1"
+padd_version="v3.4"
 
 # DATE
 today=$(date +%Y%m%d)

--- a/padd.sh
+++ b/padd.sh
@@ -1166,6 +1166,7 @@ NormalPADD() {
     pico_status=${pico_status_ok}
     mini_status_=${mini_status_ok}
     tiny_status_=${tiny_status_ok}   
+    mega_status_=${mega_status_ok}   
 
     # Start getting our information
     GetVersionInformation ${padd_size}


### PR DESCRIPTION
PADD reports "Pi-hole is offline" after temporarily disabling Pi-hole through the Web UI. This seems to only affect screens wider than 80 characters.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
PADD reports "Pi-hole is offline" after temporarily disabling Pi-hole through the Web UI. This seems to only affect screens wider than 80 characters, the 'mega' screen size.

**How does this PR accomplish the above?:**
Adds a line to update the status of the mega screen size within the NormalPADD loop.

**What documentation changes (if any) are needed to support this PR?:**
None.

---
