### PR TITLE
Fixed issues that occur if WebAdmin not installed

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -26,6 +26,9 @@ today=$(date +%Y%m%d)
 declare -i core_count=1
 core_count=$(cat /sys/devices/system/cpu/kernel_max 2> /dev/null)+1
 
+# Get Config variables
+. /etc/pihole/setupVars.conf
+
 # COLORS
 black_text=$(tput setaf 0)   # Black
 red_text=$(tput setaf 1)     # Red
@@ -511,7 +514,7 @@ GetVersionInformation() {
     fi
 
     # Gather web version information...
-    if [[ "$(source /etc/pihole/setupVars.conf; echo "$INSTALL_WEB_INTERFACE")" = true ]]; then
+    if [[ "$INSTALL_WEB_INTERFACE" = true ]]; then
       read -r -a web_versions <<< "$(pihole -v -a)"
       web_version=$(echo "${web_versions[3]}" | tr -d '\r\n[:alpha:]')
       web_version_latest=${web_versions[5]//)}
@@ -1188,9 +1191,6 @@ NormalPADD() {
     # Sizing Checks
     SizeChecker
 
-    # Get Config variables
-    . /etc/pihole/setupVars.conf
-
     # Move the cursor to top left of console to redraw
     tput cup 0 0
 
@@ -1243,10 +1243,6 @@ if [[ $# = 0 ]]; then
 
   console_width=$(tput cols)
   console_height=$(tput lines)
-
-  # Get Our Config Values
-  # shellcheck disable=SC1091
-  . /etc/pihole/setupVars.conf
 
   SizeChecker
 

--- a/padd.sh
+++ b/padd.sh
@@ -511,20 +511,27 @@ GetVersionInformation() {
     fi
 
     # Gather web version information...
-    read -r -a web_versions <<< "$(pihole -v -a)"
-    web_version=$(echo "${web_versions[3]}" | tr -d '\r\n[:alpha:]')
-    web_version_latest=${web_versions[5]//)}
-    if [[ "${web_version_latest}" == "ERROR" ]]; then
-      web_version_heatmap=${yellow_text}
-    else
-      web_version_latest=$(echo "${web_version_latest}" | tr -d '\r\n[:alpha:]')
-      # is web up-to-date?
-      if [[ "${web_version}" != "${web_version_latest}" ]]; then
-        out_of_date_flag="true"
-        web_version_heatmap=${red_text}
+    if [[ "$(source /etc/pihole/setupVars.conf; echo "$INSTALL_WEB_INTERFACE")" = true ]]; then
+      read -r -a web_versions <<< "$(pihole -v -a)"
+      web_version=$(echo "${web_versions[3]}" | tr -d '\r\n[:alpha:]')
+      web_version_latest=${web_versions[5]//)}
+      if [[ "${web_version_latest}" == "ERROR" ]]; then
+        web_version_heatmap=${yellow_text}
       else
-        web_version_heatmap=${green_text}
+        web_version_latest=$(echo "${web_version_latest}" | tr -d '\r\n[:alpha:]')
+        # is web up-to-date?
+        if [[ "${web_version}" != "${web_version_latest}" ]]; then
+          out_of_date_flag="true"
+          web_version_heatmap=${red_text}
+        else
+          web_version_heatmap=${green_text}
+        fi
       fi
+    else
+      # Web interface not installed
+      web_version_heatmap=${red_text}
+      web_version="$(printf '\x08')"  # Hex 0x08 is for backspace, to delete the leading 'v'
+      web_version="${web_version}N/A" # N/A = Not Available
     fi
 
     # Gather FTL version information...


### PR DESCRIPTION
- Show the version as N/A (Not Available) instead of v-1
- Don't show out-of-date message in status message

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fix the errors mentioned in the Commit Message. The errors occur only when Web Interface not installed.

**How does this PR accomplish the above?:**
Checks if web interface installed. If not, sets version to 'N/A' instead of `v-1`

**What documentation changes (if any) are needed to support this PR?:**
None

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
