### PR TITLE
Fix command-not-found messages on rxvt-unicode

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -37,20 +37,21 @@ core_count=$(cat /sys/devices/system/cpu/kernel_max 2> /dev/null)+1
 . /etc/pihole/setupVars.conf
 
 # COLORS
-black_text=$(tput setaf 0)   # Black
-red_text=$(tput setaf 1)     # Red
-green_text=$(tput setaf 2)   # Green
-yellow_text=$(tput setaf 3)  # Yellow
-blue_text=$(tput setaf 4)    # Blue
-magenta_text=$(tput setaf 5) # Magenta
-cyan_text=$(tput setaf 6)    # Cyan
-white_text=$(tput setaf 7)   # White
-reset_text=$(tput sgr0)      # Reset to default color
+CSI="$(printf '\033')["
+black_text="${CSI}90m"   # Black
+red_text="${CSI}91m"     # Red
+green_text="${CSI}92m"   # Green
+yellow_text="${CSI}93m"  # Yellow
+blue_text="${CSI}94m"    # Blue
+magenta_text="${CSI}95m" # Magenta
+cyan_text="${CSI}96m"    # Cyan
+white_text="${CSI}97m"   # White
+reset_text="${CSI}0m"    # Reset to default
 
 # STYLES
-bold_text=$(tput bold)
-blinking_text=$(tput blink)
-dim_text=$(tput dim)
+bold_text="${CSI}1m"
+blinking_text="${CSI}5m"
+dim_text="${CSI}2m"
 
 # CHECK BOXES
 check_box_good="[${green_text}✓${reset_text}]"       # Good


### PR DESCRIPTION
The escape sequences for rxvt-unicode contain semicolons in them. E.g.
`tput setaf 0` returns "[38;5;0m"

Now, we set heatmap colors using these escape sequences, and we store
the heatmap in ./piHoleVersion without quoting it.  So, when we source
./piHoleVersion, bash interprets the semicolons as command-separators,
and shows a bunch of errors like these -

	piHoleVersion: line 4: 5: command not found
	piHoleVersion: line 4: 2m: command not found
	piHoleVersion: line 7: 5: command not found
	piHoleVersion: line 7: 1m: command not found
	piHoleVersion: line 10: 5: command not found
	piHoleVersion: line 10: 2m: command not found
	piHoleVersion: line 13: 5: command not found
	piHoleVersion: line 13: 2m: command not found
	piHoleVersion: line 15: 5: command not found
	piHoleVersion: line 15: 2m: command not found

for reference, these are the contents of line 4, 7, 10, 13 and 15 -

	core_version_heatmap=^[[38;5;2m
	web_version_heatmap=^[[38;5;1m
	ftl_version_heatmap=^[[38;5;2m
	padd_version_heatmap=^[[38;5;2m
	version_heatmap=^[[38;5;2m

So now we quote all variables before writing them to ./piHoleVersion
Also, since we are using bash, we take advantage of the ${!varname}
expansion  (it expands to the value of the variable called "$varname",
NOT the value of the variable called "varname")

---

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
