### PR TITLE
Modified output of `pihole -v -f` breaks `GetVersionInformation`

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -527,8 +527,8 @@ GetVersionInformation() {
 
     # Gather FTL version information...
     read -r -a ftl_versions <<< "$(pihole -v -f)"
-    ftl_version=$(echo "${ftl_versions[3]}" | tr -d '\r\n[:alpha:]')
-    ftl_version_latest=${ftl_versions[5]//)}
+    ftl_version=$(echo "${ftl_versions[4]}" | tr -d '\r\n[:alpha:]')
+    ftl_version_latest=${ftl_versions[6]//)}
     if [[ "${ftl_version_latest}" == "ERROR" ]]; then
       ftl_version_heatmap=${yellow_text}
     else


### PR DESCRIPTION
Due to extra output from `pihole -v -f` the indexes for FTL version check in `GetVersionInformation` function are off by 1

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*
The latest release of pihole adds an extra word in the output of `pihole -v -f` which breaks the `GetVersionInformation` function.

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*
Moving the indexes of the captured string/array to target the location of the version numbers in the new string.

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*
None

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
