### PR TITLE
Semi-automatically handle version bumping inside padd.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Bump 'n' release
+
+on:  
+  release:
+    types: [published]
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v2
+      - 
+        name: Set the new version inside the script
+        run: |
+          GIT_TAG=${{ github.event.release.tag_name }}
+          sed -i "s/^padd_version=.*/padd_version=\"$GIT_TAG\"/" padd.sh
+      - 
+        name: Create Pull Request to update script on master branch
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: master
+          commit-message: Update report
+          committer: Pralor <pralor-bot@users.noreply.github.com>
+          author: Pralor <pralor-bot@users.noreply.github.com>
+          branch: example-patches
+          delete-branch: true
+          title: 'Bump Script Version After Release'
+          body: |
+            Bumps the `padd_version=` variable in `padd.sh` to match the most recently released version
+          labels: |
+            internal          
+      -
+        name: Attach script to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            padd.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           commit-message: Update report
           committer: Pralor <pralor-bot@users.noreply.github.com>
           author: Pralor <pralor-bot@users.noreply.github.com>
-          branch: example-patches
+          branch: bump/version
           delete-branch: true
           title: 'Bump Script Version After Release'
           body: |


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Prevents us from having to ask users to update the version string inside padd.sh before we accept a pull request.

It also allows us to merge in several pull requests before we decide to release a new version.

After merging this PR, releasing a new version will work as follows:

- Create a new release and give it a tag. e.g `v3.5.4`
- Merge PR created by the action

Here it is in action on my fork:

https://github.com/PromoFaux/PADD/releases/tag/v10001.0.0

https://github.com/PromoFaux/PADD/runs/5260069318?check_suite_focus=true

https://github.com/PromoFaux/PADD/pull/4
