### PR TITLE
Remove unused PADD.PID file

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -131,7 +131,7 @@ GetSummaryInformation() {
   clients=$(echo "${summary}" | grep "unique_clients" | grep -Eo "[0-9]+$")
 
   blocking_status=$(echo "${summary}" | grep "status" | grep -Eo "enabled|disabled|unknown" )
-  
+
   domains_being_blocked_raw=$(echo "${summary}" | grep "domains_being_blocked" | grep -Eo "[0-9]+$")
   domains_being_blocked=$(printf "%.f" "${domains_being_blocked_raw}")
 
@@ -1032,10 +1032,7 @@ StartupRoutine(){
     CheckConnectivity "$1"
     printf "%b" "Starting PADD...\n"
 
-    # Get PID of PADD
-    pid=$$
-    printf "%b" " [■·········]  10%\\r"
-    echo ${pid} > ./PADD.pid
+    echo -ne " [■·········]  10%\\r"
 
     # Check for updates
     printf "%b" " [■■········]  20%\\r"
@@ -1067,10 +1064,6 @@ StartupRoutine(){
     CheckConnectivity "$1"
 
     echo "Starting PADD."
-    # Get PID of PADD
-    pid=$$
-    echo "- Writing PID (${pid}) to file."
-    echo ${pid} > ./PADD.pid
 
     # Check for updates
     echo "- Checking for version file."
@@ -1106,11 +1099,6 @@ StartupRoutine(){
 
     printf "%b" "- Checking internet connection...\n"
     CheckConnectivity "$1"
-
-    # Get PID of PADD
-    pid=$$
-    echo "- Writing PID (${pid}) to file..."
-    echo ${pid} > ./PADD.pid
 
     # Check for updates
     echo "- Checking for PADD version file..."


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*


**How does this PR accomplish the above?:**
PADD used to write its current PID to `PADD.pid`. This was introduced in https://github.com/pi-hole/PADD/commit/ed23cdafbd2981dfaf407581dfd0038e61a4251d

However, the file seemed to be never used for anything.