### PR TITLE
fix cpu temp for non-pi devices

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -17,7 +17,7 @@ LC_NUMERIC=C
 ############################################ VARIABLES #############################################
 
 # VERSION
-padd_version="v3.6.5"
+padd_version="v3.6.6"
 
 # DATE
 today=$(date +%Y%m%d)
@@ -230,6 +230,8 @@ GetSystemInformation() {
   # CPU temperature
   if [ -f /sys/class/thermal/thermal_zone0/temp ]; then
     cpu=$(</sys/class/thermal/thermal_zone0/temp)
+  elif [ -f /sys/class/hwmon/hwmon0/temp1_input ]; then
+    cpu=$(</sys/class/hwmon/hwmon0/temp1_input)
   else
     cpu=0
   fi


### PR DESCRIPTION
after a messed up #146, here is a (hopefully) fixed PR
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
CPU Temperature Readings were not working on (presumably) some non-pi devices, in my example (asus m5a97 evo r2 with FX8350 CPU), the temperature display only worked on Pi-hole -c, not padd, looking at the code, the Pi-hole chronometer already had included the code added in this PR to chronometer, see https://github.com/pi-hole/pi-hole/blob/41bdb741b7e1a70184ecd7dbfc23f3ebcaa5e3bc/advanced/Scripts/chronometer.sh#L204
This PR is basically just there to also include those two lines of code in Padd.

**How does this PR accomplish the above?:**
Temperature is now read from `/sys/class/hwmon/hwmon0/temp1_input`, if `/sys/class/thermal/thermal_zone0/temp` does not exist.

**What documentation changes (if any) are needed to support this PR?:**
N/A
