### PR TITLE
📝 add howto run padd.sh with dockerized Pi-hole and remove link to wiki from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ wget -N https://raw.githubusercontent.com/pi-hole/PADD/master/padd.sh
 
 **Note: if you are already running Chronometer2 v1.3.1 or below, you’ll need to follow [these instructions](https://github.com/jpmck/PADD/wiki/Updating-from-Chronometer2)!**
 
-## FAQ
-
-*Answers to frequently asked questions can be found in this repo’s [wiki](https://github.com/jpmck/PADD/wiki/FAQ).*
+## Running Pi-hole in a Docker Container
+If you're running Pi-hole in a Docker Container you can use `padd.sh` this way:
+### Simplest, but quick & dirty solution:
+Copy `padd.sh` to your `/etc/pihole` volume/mount on your linux host where docker is running. Then execute `docker exec pihole /etc/pihole/padd.sh` and voila!
+### Slightly more complicated, but very elegant solution:
+If you want `padd.sh` not mixed up with your config files add this line to your [docker_run.sh](https://github.com/pi-hole/docker-pi-hole/blob/master/docker_run.sh#L14) in your Pi-hole
+`-v "${PIHOLE_BASE}/opt-padd/:/opt/padd/"`
+or [docker-compose.yml](https://github.com/pi-hole/docker-pi-hole/blob/master/docker-compose.yml.example#L19):
+```
+volumes:
+- './opt-padd/:/opt/padd/'
+```
+Where `./opt-padd` is your local directory where `padd.sh` has been copied to (or your cloned git repo).
+Then execute `docker exec pihole /opt/padd/padd.sh` and voila!


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
This PR adds a new chapter in [README](README.md) how to use `padd.sh` with a dockerized Pi-hole installation. The user is given two examples for native `docker` and also for `docker-compose`.  

This PR is a follow-up of PR #155

**How does this PR accomplish the above?:**
I've taken a screenshot of how README will look like after merging:

<img width="848" alt="grafik" src="https://user-images.githubusercontent.com/18568381/160152705-5832f100-6a7c-4a7a-8900-97f78a1e7974.png">

**What documentation changes (if any) are needed to support this PR?:**
A new chapter "Running Pi-hole in a Docker Container" has been added.
