### PR TITLE
Use /tmp instead of padd.sh dir to store temp files

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -11,10 +11,14 @@
 LC_ALL=C
 LC_NUMERIC=C
 
-# cd to the directory this script is stored in
-cd "$(dirname "$0")" || {
+# get the local temp directory
+# credits to https://unix.stackexchange.com/a/174818
+tmpdir=$(dirname "$(mktemp -u)")
+
+# cd into the temp directory
+cd "$tmpdir" || {
     EC=$?
-    echo >&2 "Could not chdir to the directory containing padd.sh (exit code $EC)"
+    echo >&2 "Could not chdir to the temp directory (exit code $EC)"
     exit $EC
 }
 

--- a/padd.sh
+++ b/padd.sh
@@ -16,7 +16,8 @@ tmpdir=$(dirname "$(mktemp -u)")
 mkdir -p "$tmpdir/padd_$(id -u)/"
 
 # change into the newly created directory
-pushd "$tmpdir/padd_$(id -u)/" > /dev/null || {
+oldpath=$(pwd)
+cd "$tmpdir/padd_$(id -u)/" > /dev/null || {
     EC=$?
     echo >&2 "Could not chdir to the temp directory (exit code $EC)"
     exit $EC
@@ -1026,7 +1027,7 @@ CheckConnectivity() {
 OutputJSON() {
   GetSummaryInformation
   echo "{\"domains_being_blocked\":${domains_being_blocked_raw},\"dns_queries_today\":${dns_queries_today_raw},\"ads_blocked_today\":${ads_blocked_today_raw},\"ads_percentage_today\":${ads_percentage_today_raw},\"clients\": ${clients}}"
-    popd > /dev/null || exit
+  cd "$oldpath" > /dev/null || exit
 }
 
 StartupRoutine(){
@@ -1037,7 +1038,7 @@ StartupRoutine(){
     CheckConnectivity "$1"
     printf "%b" "Starting PADD...\n"
 
-    echo -ne " [■·········]  10%\\r"
+    printf "%b" " [■·········]  10%\\r"
 
     # Check for updates
     printf "%b" " [■■········]  20%\\r"
@@ -1209,7 +1210,7 @@ if [ $# = 0 ]; then
   # Run PADD
   clear
   NormalPADD
-  popd > /dev/null || exit
+  cd "$oldpath" > /dev/null || exit
 fi
 
 for var in "$@"; do

--- a/padd.sh
+++ b/padd.sh
@@ -11,13 +11,11 @@
 LC_ALL=C
 LC_NUMERIC=C
 
-# get the local temp directory
-# credits to https://unix.stackexchange.com/a/174818
-tmpdir=$(dirname "$(mktemp -u)")
+# creates a new local temp directory
+tmpdir=$(mktemp -d --tmpdir padd.XXX)
 
-mkdir -p "$tmpdir/PADD/"
-# cd into the /temp/PADD/ directory
-cd "$tmpdir/padd/" || {
+# cd into the newly created /tmp/padd.XXX/ directory
+cd "$tmpdir" || {
     EC=$?
     echo >&2 "Could not chdir to the temp directory (exit code $EC)"
     exit $EC

--- a/padd.sh
+++ b/padd.sh
@@ -11,11 +11,12 @@
 LC_ALL=C
 LC_NUMERIC=C
 
-# creates a new local temp directory
-tmpdir=$(mktemp -d --tmpdir padd.XXX)
+# creates a new local temp directory /tmp/padd_uid
+tmpdir=$(dirname "$(mktemp -u)")
+mkdir -p "$tmpdir/padd_$(id -u)/"
 
-# cd into the newly created /tmp/padd.XXX/ directory
-cd "$tmpdir" || {
+# change into the newly created directory
+pushd "$tmpdir/padd_$(id -u)/" > /dev/null || {
     EC=$?
     echo >&2 "Could not chdir to the temp directory (exit code $EC)"
     exit $EC
@@ -1025,6 +1026,7 @@ CheckConnectivity() {
 OutputJSON() {
   GetSummaryInformation
   echo "{\"domains_being_blocked\":${domains_being_blocked_raw},\"dns_queries_today\":${dns_queries_today_raw},\"ads_blocked_today\":${ads_blocked_today_raw},\"ads_percentage_today\":${ads_percentage_today_raw},\"clients\": ${clients}}"
+    popd > /dev/null || exit
 }
 
 StartupRoutine(){
@@ -1207,6 +1209,7 @@ if [ $# = 0 ]; then
   # Run PADD
   clear
   NormalPADD
+  popd > /dev/null || exit
 fi
 
 for var in "$@"; do

--- a/padd.sh
+++ b/padd.sh
@@ -15,8 +15,9 @@ LC_NUMERIC=C
 # credits to https://unix.stackexchange.com/a/174818
 tmpdir=$(dirname "$(mktemp -u)")
 
-# cd into the temp directory
-cd "$tmpdir" || {
+mkdir -p "$tmpdir/PADD/"
+# cd into the /temp/PADD/ directory
+cd "$tmpdir/padd/" || {
     EC=$?
     echo >&2 "Could not chdir to the temp directory (exit code $EC)"
     exit $EC


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
With https://github.com/pi-hole/PADD/pull/168 we chdir to the dir `padd.sh` is stored in to prevent littering the files we create (~~`PADD.pid`~~ https://github.com/pi-hole/PADD/pull/197 and `piHoleVersion`). In the PR we already disused if it wouldn't be better to use `/tmp` as it should always be user-writable, but assumed the dir where `padd.sh` is located would be user-writable as well.
However, users copied `padd.sh` to dirs they have no write privileges for (`/usr/bin`), https://github.com/pi-hole/PADD/issues/207.

This PR creates our ~~files~~ `piHoleVersion` in the local temp dir (probably always `/tmp`), which should be always user-writable.