### PR TITLE
Bump version to 3.7.0

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -26,7 +26,7 @@ cd "$tmpdir/padd_$(id -u)/" > /dev/null || {
 ############################################ VARIABLES #############################################
 
 # VERSION
-padd_version="v3.6.7"
+padd_version="v3.7.0"
 
 # DATE
 today=$(date +%Y%m%d)


### PR DESCRIPTION
Version bump to 3.7.0.

As we changed quite a few things (e.g. switching to `sh` instead of `bash`) the version is increased not only by a point release.