### PR TITLE
Hotfix v3.7.1.

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -26,7 +26,7 @@ cd "$tmpdir/padd_$(id -u)/" > /dev/null || {
 ############################################ VARIABLES #############################################
 
 # VERSION
-padd_version="v3.7.0"
+padd_version="v3.7.1"
 
 # DATE
 today=$(date +%Y%m%d)

--- a/padd.sh
+++ b/padd.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 # shellcheck disable=SC1091
 
 # PADD


### PR DESCRIPTION
Fixes https://github.com/pi-hole/PADD/issues/218 by referencing `/bin/sh` instead of `/usr/bin/sh` within the shebang.

