### PR TITLE
fix alignment of ipv6 value in padd tiny

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -713,7 +713,7 @@ PrintNetworkInformation() {
   elif [ "$1" = "regular" ] || [ "$1" = "slim" ]; then
     CleanEcho "${bold_text}NETWORK ===================================================${reset_text}"
     CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "Hostname:" "${full_hostname}" "IP:" "${pi_ip4_addr}"
-    CleanPrintf " %-6s%-19s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
+    CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
     CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
     if [ "${DHCP_ACTIVE}" = "true" ]; then

--- a/padd.sh
+++ b/padd.sh
@@ -703,7 +703,7 @@ PrintNetworkInformation() {
   elif [ "$1" = "tiny" ]; then
     CleanEcho "${bold_text}NETWORK ============================================${reset_text}"
     CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "Hostname:" "${full_hostname}" "IP:  " "${pi_ip4_addr}"
-    CleanPrintf " %-6s%-39s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
+    CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
     CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
     if [ "${DHCP_ACTIVE}" = "true" ]; then


### PR DESCRIPTION
---
- **What does this PR aim to accomplish?:**

Fixes a misalignment of IPv6 value.

`broken`
![broken](https://user-images.githubusercontent.com/1605754/170710612-70ef7e88-871e-4515-95e6-fe8f9f571e94.png)

`fixed`
![fixed](https://user-images.githubusercontent.com/1605754/170710644-69c832b6-af8d-4a5b-9aee-6420f18413f5.png)


- **How does this PR accomplish the above?:**

This PR matches the surrounding code so that `IPv6` value lines up with `Hostname` (above) and `DNS` (below) values.



---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
[x] I have read the above and my PR is ready for review. _Check this box to confirm_
