### PR TITLE
Use nproc to get number of processors

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -32,8 +32,7 @@ padd_version="v3.7.1"
 today=$(date +%Y%m%d)
 
 # CORES
-core_count=1
-core_count=$(cat /sys/devices/system/cpu/kernel_max 2> /dev/null)+1
+core_count=$(nproc --all 2> /dev/null)
 
 # Get Config variables
 . /etc/pihole/setupVars.conf


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/PADD/issues/224.

As an alternative to 

This PR switches to `nproc` to get the number of processing units. It should always return a number different from `0` and therefore fix https://github.com/pi-hole/PADD/issues/224 (For a detailed bug analysis see https://github.com/pi-hole/PADD/pull/225)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
[x] I have read the above and my PR is ready for review. _Check this box to confirm_
