### PR TITLE
Add interface and traffic info to PADD

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -406,6 +406,12 @@ GetNetworkInformation() {
     conditional_forwarding_status="Disabled"
     conditional_forwarding_heatmap=${red_text}
   fi
+
+  #Default interface data
+  def_iface_data=$(GetFTLData ">interfaces" | head -n1)
+  iface_name="$(echo "$def_iface_data" | awk '{print $1}')"
+  tx_bytes="$(echo "$def_iface_data" | awk '{print $4}')"
+  rx_bytes="$(echo "$def_iface_data" | awk '{print $5}')"
 }
 
 GetPiholeInformation() {
@@ -718,6 +724,7 @@ PrintNetworkInformation() {
     CleanEcho "${bold_text}NETWORK ================================${reset_text}"
     CleanPrintf " %-9s%-19s\e[0K\\n" "Host:" "${full_hostname}"
     CleanPrintf " %-9s%-19s\e[0K\\n" "IP:"   "${pi_ip4_addr}"
+    CleanPrintf " %-9s%-8s %-4s%-5s %-4s%-5s\e[0K\\n" "Iface:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
     CleanPrintf " %-9s%-10s\e[0K\\n" "DNS:" "${dns_information}"
 
     if [ "${DHCP_ACTIVE}" = "true" ]; then
@@ -727,6 +734,7 @@ PrintNetworkInformation() {
     CleanEcho "${bold_text}NETWORK ============================================${reset_text}"
     CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "Hostname:" "${full_hostname}" "IP:  " "${pi_ip4_addr}"
     CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
+    CleanPrintf " %-10s%-16s %-4s%-5s %-4s%-5s\e[0K\\n" "Interfce:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
     CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
     if [ "${DHCP_ACTIVE}" = "true" ]; then
@@ -737,6 +745,7 @@ PrintNetworkInformation() {
     CleanEcho "${bold_text}NETWORK ===================================================${reset_text}"
     CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "Hostname:" "${full_hostname}" "IP:" "${pi_ip4_addr}"
     CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
+    CleanPrintf " %-10s%-19s %-4s%-5s %-4s%-5s\e[0K\\n" "Interfce:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
     CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
     if [ "${DHCP_ACTIVE}" = "true" ]; then
@@ -746,6 +755,7 @@ PrintNetworkInformation() {
   else
     CleanEcho "${bold_text}NETWORK =======================================================================${reset_text}"
     CleanPrintf " %-10s%-19s\e[0K\\n" "Hostname:" "${full_hostname}"
+    CleanPrintf " %-11s%-14s %-4s%-9s %-4s%-9s\e[0K\\n" "Interface:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
     CleanPrintf " %-6s%-19s %-10s%-29s\e[0K\\n" "IPv4:" "${pi_ip4_addr}" "IPv6:" "${pi_ip6_addr}"
     CleanEcho "DNS ==========================================================================="
     CleanPrintf " %-10s%-39s\e[0K\\n" "Servers:" "${dns_information}"


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Adds the default interface (the one connected to the gateway) and the traffic send over this interface to `PADD` for screen sizes  `mini` and bigger.

![Bildschirmfoto zu 2022-06-25 22-33-44](https://user-images.githubusercontent.com/26622301/175790110-05dea812-811e-4696-99d1-d936dbf316b0.png)

- **How does this PR accomplish the above?:**

Uses the FTL Telnet API endpoint `>interfaces` added by https://github.com/pi-hole/FTL/pull/1355


- **What documentation changes (if any) are needed to support this PR?:**

Release notes needs a warning that it will only work with the latest FTL version


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
