### PR TITLE
Use FTL >gateway endpoint to get router IP

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -377,7 +377,7 @@ GetNetworkInformation() {
     # if the DHCP Router variable isn't set
     # Issue 3: https://github.com/jpmck/PADD/issues/3
     if [ -z ${DHCP_ROUTER+x} ]; then
-      DHCP_ROUTER=$(/sbin/ip route | awk '/default/ { printf "%s\t", $3 }')
+      DHCP_ROUTER=$(GetFTLData "gateway" | awk '{ printf "%s\t", $1 }')
     fi
 
     dhcp_info=" Router:   ${DHCP_ROUTER}"

--- a/padd.sh
+++ b/padd.sh
@@ -377,7 +377,7 @@ GetNetworkInformation() {
     # if the DHCP Router variable isn't set
     # Issue 3: https://github.com/jpmck/PADD/issues/3
     if [ -z ${DHCP_ROUTER+x} ]; then
-      DHCP_ROUTER=$(GetFTLData "gateway" | awk '{ printf "%s\t", $1 }')
+      DHCP_ROUTER=$(GetFTLData "gateway" | awk '{ printf $1 }')
     fi
 
     dhcp_info=" Router:   ${DHCP_ROUTER}"


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Get the gateway/router IP if Pi-hole isn't the DHCP server via `>gateway` API endpoint introduced by https://github.com/pi-hole/FTL/pull/1354

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
