### PR TITLE
Add yaml and markdown linters to stickler

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -3,4 +3,5 @@ linters:
   shellcheck:
     shell: bash
   yamllint:
+    config: ./.yamllint.conf
   remarklint:

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,3 +1,6 @@
+---
 linters:
   shellcheck:
     shell: bash
+  yamllint:
+  remarklint:

--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -1,0 +1,3 @@
+rules:
+  line-length: disable
+  document-start: disable


### PR DESCRIPTION
Add yaml and markdown linters to the stickler workflow

Uses https://pypi.org/project/yamllint/ and https://github.com/remarkjs/remark-lint internally
