### PR TITLE
Remove the note about not supporting Pi-hole beta versions from PADD issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,13 +4,12 @@ about: Create a report to help us improve
 
 ---
 
-*Before submitting a bug report, are you using a test version of Pi-hole? If so, PADD doesn‘t support beta versions of Pi-hole!*
-
 **Describe the bug**
 A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. ...
 2. ...
 


### PR DESCRIPTION
Removes the note about not supporting Pi-hole beta versions from the `PADD` issue template.

`PADD` is now compatible with non-master branches, see PR https://github.com/pi-hole/PADD/pull/232. 

Also, if there are incompatibilities we want to see them early. 