### PR TITLE
Remove wrongly added > on FTL API call

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -408,7 +408,7 @@ GetNetworkInformation() {
   fi
 
   #Default interface data
-  def_iface_data=$(GetFTLData ">interfaces" | head -n1)
+  def_iface_data=$(GetFTLData "interfaces" | head -n1)
   iface_name="$(echo "$def_iface_data" | awk '{print $1}')"
   tx_bytes="$(echo "$def_iface_data" | awk '{print $4}')"
   rx_bytes="$(echo "$def_iface_data" | awk '{print $5}')"


### PR DESCRIPTION
Fixes a small bug introduced by https://github.com/pi-hole/PADD/pull/233.

`GetFTLData()` already adds the leading `>` so there is no need to add it again during the function call.