### PR TITLE
Optimize polling

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -86,6 +86,7 @@ mega_status_unknown="${check_box_question} Unable to determine Pi-hole status."
 # TINY STATUS
 tiny_status_ok="${check_box_good} System is healthy."
 tiny_status_update="${check_box_info} Updates are available."
+tiny_status_hot="${check_box_bad} System is hot!"
 tiny_status_off="${check_box_bad} Pi-hole is offline"
 tiny_status_ftl_down="${check_box_info} FTL is down!"
 tiny_status_dns_down="${check_box_bad} DNS is off!"
@@ -230,8 +231,9 @@ GetSystemInformation() {
   if [ ${cpu} -gt 80000 ]; then
     temp_heatmap=${blinking_text}${red_text}
     pico_status="${pico_status_hot}"
-    mini_status_="${mini_status_hot} ${blinking_text}${red_text}${temperature}${reset_text}"
-    full_status_="${full_status_hot} ${blinking_text}${red_text}${temperature}${reset_text}"
+    mini_status="${mini_status_hot} ${blinking_text}${red_text}${temperature}${reset_text}"
+    tiny_status="${tiny_status_hot} ${blinking_text}${red_text}${temperature}${reset_text}"
+    full_status="${full_status_hot} ${blinking_text}${red_text}${temperature}${reset_text}"
     mega_status="${mega_status_hot} ${blinking_text}${red_text}${temperature}${reset_text}"
   elif [ ${cpu} -gt 70000 ]; then
     temp_heatmap=${magenta_text}
@@ -410,9 +412,9 @@ GetPiholeInformation() {
     ftl_heatmap=${yellow_text}
     ftl_check_box=${check_box_info}
     pico_status=${pico_status_ftl_down}
-    mini_status_=${mini_status_ftl_down}
-    tiny_status_=${tiny_status_ftl_down}
-    full_status_=${full_status_ftl_down}
+    mini_status=${mini_status_ftl_down}
+    tiny_status=${tiny_status_ftl_down}
+    full_status=${full_status_ftl_down}
     mega_status=${mega_status_ftl_down}
   else
     ftl_status="Running"
@@ -431,9 +433,9 @@ GetPiholeInformation() {
     pihole_heatmap=${red_text}
     pihole_check_box=${check_box_bad}
     pico_status=${pico_status_dns_down}
-    mini_status_=${mini_status_dns_down}
-    tiny_status_=${tiny_status_dns_down}
-    full_status_=${full_status_dns_down}
+    mini_status=${mini_status_dns_down}
+    tiny_status=${tiny_status_dns_down}
+    full_status=${full_status_dns_down}
     mega_status=${mega_status_dns_down}
   else
     if [ "${blocking_status}" = "enabled" ]; then
@@ -446,9 +448,9 @@ GetPiholeInformation() {
       pihole_heatmap=${red_text}
       pihole_check_box=${check_box_bad}
       pico_status=${pico_status_off}
-      mini_status_=${mini_status_off}
-      tiny_status_=${tiny_status_off}
-      full_status_=${full_status_off}
+      mini_status=${mini_status_off}
+      tiny_status=${tiny_status_off}
+      full_status=${full_status_off}
       mega_status=${mega_status_off}
     fi
     if [ "${blocking_status}" = "unknown" ]; then
@@ -456,9 +458,9 @@ GetPiholeInformation() {
       pihole_heatmap=${yellow_text}
       pihole_check_box=${check_box_question}
       pico_status=${pico_status_unknown}
-      mini_status_=${mini_status_unknown}
-      tiny_status_=${tiny_status_unknown}
-      full_status_=${full_status_unknown}
+      mini_status=${mini_status_unknown}
+      tiny_status=${tiny_status_unknown}
+      full_status=${full_status_unknown}
       mega_status=${mega_status_unknown}
     fi
   fi
@@ -557,26 +559,26 @@ GetVersionInformation() {
   if [ "${out_of_date_flag}" = "true" ]; then
     version_status="Pi-hole is out-of-date!"
     pico_status=${pico_status_update}
-    mini_status_=${mini_status_update}
-    tiny_status_=${tiny_status_update}
-    full_status_=${full_status_update}
+    mini_status=${mini_status_update}
+    tiny_status=${tiny_status_update}
+    full_status=${full_status_update}
     mega_status=${mega_status_update}
   else
     # but is PADD out-of-date?
     if [ "${padd_out_of_date_flag}" = "true" ]; then
       version_status="PADD is out-of-date!"
       pico_status=${pico_status_update}
-      mini_status_=${mini_status_update}
-      tiny_status_=${tiny_status_update}
-      full_status_=${full_status_update}
+      mini_status=${mini_status_update}
+      tiny_status=${tiny_status_update}
+      full_status=${full_status_update}
       mega_status=${mega_status_update}
     # else, everything is good!
     else
       version_status="Pi-hole is up-to-date!"
       pico_status=${pico_status_ok}
-      mini_status_=${mini_status_ok}
-      tiny_status_=${tiny_status_ok}
-      full_status_=${full_status_ok}
+      mini_status=${mini_status_ok}
+      tiny_status=${tiny_status_ok}
+      full_status=${full_status_ok}
       mega_status=${mega_status_ok}
     fi
   fi
@@ -605,24 +607,24 @@ PrintLogo() {
   if [ "$1" = "pico" ]; then
     CleanEcho "p${padd_text} ${pico_status}"
   elif [ "$1" = "nano" ]; then
-    CleanEcho "n${padd_text} ${mini_status_}"
+    CleanEcho "n${padd_text} ${mini_status}"
   elif [ "$1" = "micro" ]; then
-    CleanEcho "µ${padd_text}     ${mini_status_}"
+    CleanEcho "µ${padd_text}     ${mini_status}"
     CleanEcho ""
   elif [ "$1" = "mini" ]; then
-    CleanEcho "${padd_text}${dim_text}mini${reset_text}  ${mini_status_}"
+    CleanEcho "${padd_text}${dim_text}mini${reset_text}  ${mini_status}"
     CleanEcho ""
   elif [ "$1" = "tiny" ]; then
     CleanEcho "${padd_text}${dim_text}tiny${reset_text}   Pi-hole® ${core_version_heatmap}${core_version}${reset_text}, Web ${web_version_heatmap}${web_version}${reset_text}, FTL ${ftl_version_heatmap}${ftl_version}${reset_text}"
-    CleanPrintf "           PADD ${padd_version_heatmap}${padd_version}${reset_text} ${tiny_status_}${reset_text}\e[0K\\n"
+    CleanPrintf "           PADD ${padd_version_heatmap}${padd_version}${reset_text} ${tiny_status}${reset_text}\e[0K\\n"
   elif [ "$1" = "slim" ]; then
-    CleanEcho "${padd_text}${dim_text}slim${reset_text}   ${full_status_}"
+    CleanEcho "${padd_text}${dim_text}slim${reset_text}   ${full_status}"
     CleanEcho ""
   # For the next two, use printf to make sure spaces aren't collapsed
   elif [ "$1" = "regular" ] || [ "$1" = "slim" ]; then
     CleanPrintf "${padd_logo_1}\e[0K\\n"
     CleanPrintf "${padd_logo_2}Pi-hole® ${core_version_heatmap}${core_version}${reset_text}, Web ${web_version_heatmap}${web_version}${reset_text}, FTL ${ftl_version_heatmap}${ftl_version}${reset_text}\e[0K\\n"
-    CleanPrintf "${padd_logo_3}PADD ${padd_version_heatmap}${padd_version}${reset_text}   ${full_status_}${reset_text}\e[0K\\n"
+    CleanPrintf "${padd_logo_3}PADD ${padd_version_heatmap}${padd_version}${reset_text}   ${full_status}${reset_text}\e[0K\\n"
     CleanEcho ""
   # normal or not defined
   else
@@ -998,7 +1000,7 @@ OutputJSON() {
 }
 
 StartupRoutine(){
-    # Get Config variables
+    # Get config variables
   . /etc/pihole/setupVars.conf
 
   if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
@@ -1040,6 +1042,7 @@ StartupRoutine(){
     echo "- Gathering system info."
     GetSystemInformation "mini"
     echo "- Gathering Pi-hole info."
+    GetPiholeInformation "mini"
     GetSummaryInformation "mini"
     echo "- Gathering network info."
     GetNetworkInformation "mini"
@@ -1111,8 +1114,10 @@ NormalPADD() {
     tput ed
 
     pico_status=${pico_status_ok}
-    mini_status_=${mini_status_ok}
-    tiny_status_=${tiny_status_ok}
+    mini_status=${mini_status_ok}
+    tiny_status=${tiny_status_ok}
+    full_status=${full_status_ok}
+    mega_status=${mega_status_ok}
 
     # Sleep for 5 seconds
     sleep 5


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This PR solves more than one, but connected issues.
`PADD` has five `GetXXXInformation` routines which were executed every 5 seconds. One of them had a check (`GetVersionInformation`) that the function is only executed once a day by writing `today` into the `piHoleVersion_file` and checking that date against now. On every startup or after a date change the file was deleted to update the information. 
All other `GetXXXInformation` routines did not have such a check. But some of those gathered information are unlikely to update every 5 seconds, e.g. `hostname`, `IPv4` address, `DNSSEC status`, etc.

To allow setting individual polling times, each `GetXXXInformation` routine is now wrapped in a checker, which checks that last execution time is more than xx seconds in the past.
This also allows us to get rid of the `piHoleVersion_file` which was basically used to hold a timestamp and some information for re-use.

___

Additionally, this PR 

- fixes a bug which was introduced by https://github.com/pi-hole/PADD/pull/165/commits/06fe88fca51cd5ad543193383663279463c2b286 where `setupVars.conf` was only sourced at the beginning of the script. However, we need to source repeatedly to check if settings (like `DNSSEC` status) have changed
- added `GetPiholeInformation` to the startup routine for `${padd_size}=mini`. This was likely forgotten a long time ago already
- moves the `sleep 5` above the execution of the `GetXXXInformation` routines which allows to display "non-stale" (5 sec old) data
- adds a few missing "size"_status, see PR https://github.com/pi-hole/PADD/pull/144 for one of them


- **How does this PR accomplish the above?:**

Add individual timers for each check. Remove now unused `piHoleVersion_file`

___

P.S. Comparison on GH looks worse than in reality. Most are indention changes in `GetVersionInformation`

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
