### PR TITLE
Remove empty line after IPv6 on tiny and regular

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -670,7 +670,7 @@ PrintNetworkInformation() {
   elif [ "$1" = "tiny" ]; then
     CleanEcho "${bold_text}NETWORK ============================================${reset_text}"
     CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "Hostname:" "${full_hostname}" "IP:  " "${pi_ip4_addr}"
-    CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
+    CleanPrintf " %-10s%-16s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
     CleanPrintf " %-10s%-16s %-4s%-5s %-4s%-5s\e[0K\\n" "Interfce:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
     CleanPrintf " %-10s%-16s %-8s%-16s\e[0K\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 
@@ -681,7 +681,7 @@ PrintNetworkInformation() {
   elif [ "$1" = "regular" ] || [ "$1" = "slim" ]; then
     CleanEcho "${bold_text}NETWORK ===================================================${reset_text}"
     CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "Hostname:" "${full_hostname}" "IP:" "${pi_ip4_addr}"
-    CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
+    CleanPrintf " %-10s%-19s\e[0K\\n" "IPv6:" "${pi_ip6_addr}"
     CleanPrintf " %-10s%-19s %-4s%-5s %-4s%-5s\e[0K\\n" "Interfce:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
     CleanPrintf " %-10s%-19s %-10s%-19s\e[0K\\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_heatmap}${dnssec_status}${reset_text}"
 


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

PR https://github.com/pi-hole/PADD/pull/226 fixed the left hand alignment of IPv6 on `tiny` and `slim|regular`. However, it introduced unnecessary spaces to the right which will be shown as empty line on screens with low width.
This PR removes the spaces.

Smallest `tiny` with 53x20, smallest regular with 60x22. Note: The vertical issue (https://github.com/pi-hole/PADD/issues/251) will be fixed later.

Before
![Bildschirmfoto zu 2022-07-27 10-01-15](https://user-images.githubusercontent.com/26622301/181194637-7bb2a09e-da67-44d7-8f8a-4d8093eefd5c.png)

After
![Bildschirmfoto zu 2022-07-27 10-01-42](https://user-images.githubusercontent.com/26622301/181194670-8dc32141-e16b-4371-b0c1-c3c7364abe25.png)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
