### PR TITLE
Wait until telnet server said everything

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -110,7 +110,8 @@ GetFTLData() {
     ftl_port=$(cat /run/pihole-FTL.port 2> /dev/null)
     if [ -n "$ftl_port" ]; then
       # Send command to FTL and ask to quit when finished
-      echo ">$1 >quit" | nc 127.0.0.1 "${ftl_port}"
+      data="$(echo ">$1 >quit" | nc 127.0.0.1 "${ftl_port}")"
+      echo "${data}"
     else
       echo "0"
     fi

--- a/padd.sh
+++ b/padd.sh
@@ -107,6 +107,7 @@ padd_logo_retro_3="${bold_text}${green_text}|   ${red_text}/${yellow_text}-${gre
 ############################################# GETTERS ##############################################
 
 GetFTLData() {
+    local ftl_port data
     ftl_port=$(cat /run/pihole-FTL.port 2> /dev/null)
     if [ -n "$ftl_port" ]; then
       # Send command to FTL and ask to quit when finished


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When we switched to `netcat` for communication with FTL's API, we did not ensure that the server could send all data. 
This resulted in `FTL.log` getting filled with 

```
[2022-07-29 18:30:58.941 6051/T8531] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:58.941 6051/T8531] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:58.966 6051/T8545] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Connection reset by peer
[2022-07-29 18:30:58.966 6051/T8545] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:58.966 6051/T8545] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:58.966 6051/T8545] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:59.020 6051/T8573] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Connection reset by peer
[2022-07-29 18:30:59.020 6051/T8573] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:59.121 6051/T8629] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Connection reset by peer
[2022-07-29 18:30:59.121 6051/T8629] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:59.121 6051/T8629] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:59.121 6051/T8629] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:59.146 6051/T8643] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Connection reset by peer
[2022-07-29 18:30:59.147 6051/T8643] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:59.147 6051/T8643] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:30:59.147 6051/T8643] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe
[2022-07-29 18:31:14.307 6051/T8695] WARN: Could not write() everything in ssend() [/__w/FTL/FTL/src/api/socket.c:245]: Broken pipe

```


- **How does this PR accomplish the above?:**

Save the output to a variable first, then echo as function return.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
