### PR TITLE
Remove connectivity check on startup

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -936,70 +936,6 @@ SizeChecker(){
   fi
 }
 
-CheckConnectivity() {
-    local connectivity connection_attempts wait_timer
-
-    connectivity="false"
-    connection_attempts=1
-    wait_timer=1
-
-    while [ $connection_attempts -lt 9 ]; do
-
-        if nc -zw1 google.com 443 2>/dev/null; then
-            if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
-                echo "Attempt #${connection_attempts} passed..."
-            elif [ "$1" = "mini" ]; then
-                echo "Attempt ${connection_attempts} passed."
-            else
-                echo "  - Attempt ${connection_attempts} passed...                                     "
-            fi
-
-            connectivity="true"
-            connection_attempts=11
-        else
-            connection_attempts=$((connection_attempts+1))
-            local inner_wait_timer
-            inner_wait_timer=$((wait_timer*1))
-
-            # echo "$wait_timer = $inner_wait_timer"
-            while [ $inner_wait_timer -gt 0 ]; do
-                if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
-                    printf "%b" "Attempt #${connection_attempts} failed...\r"
-                elif [ "$1" = "mini" ] || [ "$1" = "tiny" ]; then
-                    printf "%b" "- Attempt ${connection_attempts} failed, wait ${inner_wait_timer}  \r"
-                else
-                    printf "%b" "  - Attempt ${connection_attempts} failed... waiting ${inner_wait_timer} seconds...  \r"
-                fi
-                sleep 1
-                inner_wait_timer=$((inner_wait_timer-1))
-            done
-
-            # echo -ne "Attempt $connection_attempts failed... waiting $wait_timer seconds...\r"
-            # sleep $wait_timer
-            wait_timer=$((wait_timer*2))
-        fi
-
-    done
-
-    if [ "$connectivity" = "false" ]; then
-        if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
-            echo "Check failed..."
-        elif [ "$1" = "mini" ] || [ "$1" = "tiny" ]; then
-            echo "- Connectivity check failed."
-        else
-            echo "  - Connectivity check failed..."
-        fi
-    else
-        if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
-            echo "Check passed..."
-        elif [ "$1" = "mini" ] || [ "$1" = "tiny" ]; then
-            echo "- Connectivity check passed."
-        else
-            echo "  - Connectivity check passed..."
-        fi
-    fi
-}
-
 # converts a given version string e.g. v3.7.1 to 3007001000 to allow for easier comparison of multi digit version numbers
 # credits https://apple.stackexchange.com/a/123408
 VersionConverter() {
@@ -1042,9 +978,6 @@ StartupRoutine(){
   if [ "$1" = "pico" ] || [ "$1" = "nano" ] || [ "$1" = "micro" ]; then
     PrintLogo "$1"
     printf "%b" "START-UP ===========\n"
-    printf "%b" "Checking connection.\n"
-    CheckConnectivity "$1"
-    printf "%b" "Starting PADD...\n"
 
     printf "%b" " [■·········]  10%\r"
 
@@ -1069,10 +1002,6 @@ StartupRoutine(){
   elif [ "$1" = "mini" ]; then
     PrintLogo "$1"
     echo "START UP ====================="
-    echo "Checking connectivity."
-    CheckConnectivity "$1"
-
-    echo "Starting PADD."
 
     # Get our information for the first time
     echo "- Gathering system info."
@@ -1097,9 +1026,6 @@ StartupRoutine(){
     else
       echo "START UP ==================================================="
     fi
-
-    printf "%b" "- Checking internet connection...\n"
-    CheckConnectivity "$1"
 
     # Get our information for the first time
     echo "- Gathering system information..."


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Removes the connectivity check during PADD startup. I meant to do this for a long time already, because I think the function serves no purpose.
1) It checks, whether PADD can reach a google server. However, we do not want anything from this server
2) It only checks during start up and never again. What if the connection dies later?
3) It does not stop startup if it could not establish a connection.
4) PADD displays information provided by `FTL`. We already check if `FTL` is available (`pidof pihole-FTL`). We perform this check repeatedly.
5) Pi-hole itself does not check nor warn if there is no outside connection. Why should PADD?

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
