### PR TITLE
Re-order network info in mini

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -748,8 +748,8 @@ PrintDashboard() {
             moveXOffset; printf " %-9s%-29s${clear_line}\n" "Top Ad:" "${top_blocked}"
         fi
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK ================================${reset_text}"
-        moveXOffset; printf " %-9s%-15s%-4s%-11s${clear_line}\n" "Host:" "${full_hostname}" "IP:"   "${pi_ip4_addr}"
-        moveXOffset; printf " %-9s%-8s %-4s%-5s %-4s%-5s${clear_line}\n" "Iface:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
+        moveXOffset; printf " %-9s%-19s${clear_line}\n" "Host:" "${full_hostname}"
+        moveXOffset; printf " %-9s%-19s${clear_line}\n" "IP:" "${pi_ip4_addr}"
         moveXOffset; printf " %-9s%-10s${clear_line}\n" "DNS:" "${dns_information}"
         if [ "${DHCP_ACTIVE}" = "true" ]; then
             moveXOffset; printf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}

--- a/padd.sh
+++ b/padd.sh
@@ -748,9 +748,9 @@ PrintDashboard() {
             moveXOffset; printf " %-9s%-29s${clear_line}\n" "Top Ad:" "${top_blocked}"
         fi
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK ================================${reset_text}"
-        moveXOffset; printf " %-9s%-19s${clear_line}\n" "Host:" "${full_hostname}"
-        moveXOffset; printf " %-9s%-19s${clear_line}\n" "IP:" "${pi_ip4_addr}"
-        moveXOffset; printf " %-9s%-10s${clear_line}\n" "DNS:" "${dns_information}"
+        moveXOffset; printf " %-9s%-16s%-5s%-9s${clear_line}\n" "Host:" "${full_hostname}" "DNS:" "${dns_information}"
+        moveXOffset; printf " %-9s%s${clear_line}\n" "IP:" "${pi_ip4_addr} (${iface_name})"
+        moveXOffset; printf " %-9s%-4s%-5s %-4s%-5s${clear_line}\n" "Traffic:" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
         if [ "${DHCP_ACTIVE}" = "true" ]; then
             moveXOffset; printf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
         fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Removes interface and TX/RX info from PADD in size `mini`
Those were added by https://github.com/pi-hole/PADD/pull/233. In https://github.com/pi-hole/PADD/pull/257/commits/b37543508d006deedbb70aaeb1ffc7bd36b163d3 I reduced the number of lines by one to fit it in 18 lines (which is the smallest height for `mini`) by printing the IP next to the host name.

However, this will fail for long hostnames and/or long IPs.
![image](https://user-images.githubusercontent.com/26622301/197985192-6c5f62e4-ffd9-4cba-8d7b-46f3c1dea387.png)

Also the TX/RX won't fit if traffic increases

![Screenshot at 2022-10-26 11-18-14](https://user-images.githubusercontent.com/26622301/197987748-28df83b1-edd7-4ea1-9663-8939dfe34c1d.png)

___

In summary, `mini` is just to small to add those infos - so remove them.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
