### PR TITLE
Remove special handling of certain upstream DNS server

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -300,7 +300,6 @@ GetNetworkInformation() {
 
   # Get hostname and gateway
   pi_hostname=$(hostname)
-  pi_gateway=$(ip r | grep 'default' | awk '{print $3}')
 
   full_hostname=${pi_hostname}
   # does the Pi-hole have a domain set?
@@ -329,15 +328,9 @@ GetNetworkInformation() {
 
   # if there's only one DNS server
   if [ ${dns_count} -eq 1 ]; then
-    if [ "${PIHOLE_DNS_1}" = "127.0.0.1#5053" ]; then
-      dns_information="1 server (Cloudflared)"
-    elif [ "${PIHOLE_DNS_1}" = "${pi_gateway}#53" ]; then
-      dns_information="1 server (gateway)"
-    else
       dns_information="1 server"
-    fi
-  elif [ ${dns_count} -gt 8 ]; then
-    dns_information="8+ servers"
+  elif [ ${dns_count} -gt 9 ]; then
+    dns_information="9+ servers"
   else
     dns_information="${dns_count} servers"
   fi

--- a/padd.sh
+++ b/padd.sh
@@ -329,8 +329,6 @@ GetNetworkInformation() {
   # if there's only one DNS server
   if [ ${dns_count} -eq 1 ]; then
       dns_information="1 server"
-  elif [ ${dns_count} -gt 9 ]; then
-    dns_information="9+ servers"
   else
     dns_information="${dns_count} servers"
   fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Simplifies the upstream DNS server count/naming. We had special "names" for some upstream servers (Cloudflared, gateway) but the choice seems a bit arbitrary. If we had more than 8 upstream DNS server, we also would indicated this.

This PR allows only 2  cases now:
1) exactly 1 server
2) more than 1 server

P.S. Removes now unused variable `$pi_gateway`

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
