### PR TITLE
Redirecting error to `dev/null` if the file doesn't exist

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -218,8 +218,9 @@ GetSystemInformation() {
   # Device model
   if [ -f /sys/devices/virtual/dmi/id/product_name ] || [ -f /sys/devices/virtual/dmi/id/product_family ]; then
     # Get model, remove possible null byte
-    product_name=$(tr -d '\0' < /sys/devices/virtual/dmi/id/product_name)
-    product_family=$(tr -d '\0' < /sys/devices/virtual/dmi/id/product_family)
+    # There are no guarantees both files exist. Redirecting error to dev/null
+    product_name=$(cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null | tr -d '\0')
+    product_family=$(cat /sys/devices/virtual/dmi/id/product_family 2>/dev/null | tr -d '\0')
     sys_model="$(echo "$product_name" | grep "$product_family")"
 
     # If product_family is not contained in product_name, both are shown
@@ -229,8 +230,9 @@ GetSystemInformation() {
   elif [ -f /sys/firmware/devicetree/base/model ]; then
     sys_model=$(tr -d '\0' < /sys/firmware/devicetree/base/model)
   elif [ -f /sys/devices/virtual/dmi/id/board_vendor ] || [ -f /sys/devices/virtual/dmi/id/board_name ]; then
-    sys_model=$(tr -d '\0' < /sys/devices/virtual/dmi/id/board_vendor)
-    sys_model="$sys_model $(tr -d '\0' < /sys/devices/virtual/dmi/id/board_name)"
+    # There are no guarantees both files exist. Redirecting error to dev/null
+    sys_model=$(cat /sys/devices/virtual/dmi/id/board_vendor 2>/dev/null | tr -d '\0')
+    sys_model="$sys_model $(cat /sys/devices/virtual/dmi/id/board_name 2>/dev/null | tr -d '\0')"
   elif [ -f /tmp/sysinfo/model ]; then
     sys_model=$(tr -d '\0' < /tmp/sysinfo/model)
   fi

--- a/padd.sh
+++ b/padd.sh
@@ -243,6 +243,9 @@ GetSystemInformation() {
     fi
   elif [ -f /tmp/sysinfo/model ]; then
     sys_model=$(tr -d '\0' < /tmp/sysinfo/model)
+  elif [ -f /pihole.docker.tag ]; then
+    # Docker image. Remove final line break
+    sys_model=$(tr -d '\n' < /pihole.docker.tag)
   fi
 
   # Cleaning device model from useless OEM information


### PR DESCRIPTION
### What does this PR aim to accomplish?:

Issue #293 shows an error in Synology, because only one of the expected files exists.
An error message is printed and quickly removed, but it is visible.

**Details:**
Line 219 verifies if at least one of the files exist.
If only one exists, the other one will cause an error (lines 221 and 222).

**Note:**
The same error can happen on another test (lines 231-233).

### How does this PR accomplish the above?:

Instead of filling the function with many more `if` tests, this PR only sends the error message to `dev/null` and use the empty return.
The fix were applied in both cases.


### Link documentation PRs if any are needed to support this PR:

none

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
