### PR TITLE
Try to reduce flickering

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -684,13 +684,8 @@ PrintLogo() {
 }
 
 PrintDashboard() {
-    # Clear the screen and move cursor to (0,0).
-    # This mimics the 'clear' command.
-    # https://vt100.net/docs/vt510-rm/ED.html
-    # https://vt100.net/docs/vt510-rm/CUP.html
-    # E3 extension `\e[3J` to clear the scrollback buffer (see 'man clear')
-
-    printf '\e[H\e[2J\e[3J'
+    # Move cursor to (0,0).
+    printf '\e[H'
 
     # adds the y-offset
     moveYOffset
@@ -932,8 +927,8 @@ SizeChecker(){
     # this reduces "flickering" of GenerateSizeDependendOutput() items
     # after a terminal re-size
     sleep 0.1
-    console_height=$(stty size | awk '{ print $1 }')
-    console_width=$(stty size | awk '{ print $2 }')
+    console_width=$(tput cols)
+    console_height=$(tput lines)
 
     # Mega
     if [ "$console_width" -ge "80" ] && [ "$console_height" -ge "26" ]; then
@@ -1259,6 +1254,15 @@ TerminalResize(){
     # kill the sleep function within NormalPADD() to trigger redrawing
     # of the Dashboard
     SizeChecker
+
+    # Clear the screen and move cursor to (0,0).
+    # This mimics the 'clear' command.
+    # https://vt100.net/docs/vt510-rm/ED.html
+    # https://vt100.net/docs/vt510-rm/CUP.html
+    # E3 extension `\e[3J` to clear the scrollback buffer (see 'man clear')
+
+    printf '\e[H\e[2J\e[3J'
+
     kill $sleepPID > /dev/null 2>&1
 }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

The major redesign of the way the dashboard is printed (https://github.com/pi-hole/PADD/pull/268) has introduced flickering on external displays (https://github.com/pi-hole/PADD/issues/290).

This PR is fixing this in two ways: 
1) Use `tput` instead of `stty` to obtain the amount of rows and columns after a window resize. (The idea was to use `stty` because it has less overhead and is faster than `tput`). 
2) The whole screen is not erased anymore before each refresh, but only when the window is resized.

Fixes https://github.com/pi-hole/PADD/issues/290 and https://github.com/pi-hole/PADD/issues/288
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
