### PR TITLE
Don't use hashes to check for updates on master

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -468,14 +468,16 @@ GetVersionInformation() {
   # Extract vx.xx or vx.xx.xxx version
   CORE_VERSION="$(echo "${CORE_VERSION}" | grep -oE '^v[0-9]+([.][0-9]+){1,2}')"
   if [ "${CORE_BRANCH}" = "master" ]; then
-    if [ "${CORE_HASH}" = "${GITHUB_CORE_HASH}" ]; then
-        # up-to-date
-        core_version_heatmap=${green_text}
-      else
-        #out-of-date
-        out_of_date_flag="true"
-        core_version_heatmap=${red_text}
-      fi
+    core_version_converted="$(VersionConverter "${CORE_VERSION}")"
+    core_version_latest_converted=$(VersionConverter "${GITHUB_CORE_VERSION}")
+
+    if [ "${core_version_converted}" -lt "${core_version_latest_converted}" ]; then
+      out_of_date_flag="true"
+      core_version_heatmap=${red_text}
+    else
+      core_version_heatmap=${green_text}
+    fi
+
   else
     # Custom branch
     if [ -z "${CORE_BRANCH}"  ]; then
@@ -483,7 +485,14 @@ GetVersionInformation() {
       core_version_heatmap=${red_text}
       CORE_VERSION="?"
     else
-      core_version_heatmap=${yellow_text}
+      if [ "${CORE_HASH}" = "${GITHUB_CORE_HASH}" ]; then
+        # up-to-date
+        core_version_heatmap=${green_text}
+      else
+        # out-of-date
+        out_of_date_flag="true"
+        core_version_heatmap=${red_text}
+      fi
       # shorten common branch names (fix/, tweak/, new/)
       # use the first 7 characters of the branch name as version
       CORE_VERSION="$(printf '%s' "$CORE_BRANCH" | sed 's/fix\//f\//;s/new\//n\//;s/tweak\//t\//' | cut -c 1-7)"
@@ -495,14 +504,16 @@ GetVersionInformation() {
   if [ "$INSTALL_WEB_INTERFACE" = true ]; then
     WEB_VERSION="$(echo "${WEB_VERSION}" | grep -oE '^v[0-9]+([.][0-9]+){1,2}')"
     if [ "${WEB_BRANCH}" = "master" ]; then
-      if [ "${WEB_HASH}" = "${GITHUB_WEB_HASH}" ]; then
-          # up-to-date
-          web_version_heatmap=${green_text}
-        else
-          #out-of-date
-          out_of_date_flag="true"
-          web_version_heatmap=${red_text}
-        fi
+      web_version_converted="$(VersionConverter "${WEB_VERSION}")"
+      web_version_latest_converted=$(VersionConverter "${GITHUB_WEB_VERSION}")
+
+      if [ "${web_version_converted}" -lt "${web_version_latest_converted}" ]; then
+        out_of_date_flag="true"
+        web_version_heatmap=${red_text}
+      else
+        web_version_heatmap=${green_text}
+      fi
+
     else
     # Custom branch
       if [ -z "${WEB_BRANCH}"  ]; then
@@ -510,7 +521,14 @@ GetVersionInformation() {
         web_version_heatmap=${red_text}
         WEB_VERSION="?"
       else
-        web_version_heatmap=${yellow_text}
+        if [ "${WEB_HASH}" = "${GITHUB_WEB_HASH}" ]; then
+          # up-to-date
+          web_version_heatmap=${green_text}
+        else
+          # out-of-date
+          out_of_date_flag="true"
+          web_version_heatmap=${red_text}
+        fi
         # shorten common branch names (fix/, tweak/, new/)
         # use the first 7 characters of the branch name as version
         WEB_VERSION="$(printf '%s' "$WEB_BRANCH" | sed 's/fix\//f\//;s/new\//n\//;s/tweak\//t\//' | cut -c 1-7)"
@@ -526,14 +544,15 @@ GetVersionInformation() {
   # Extract vx.xx or vx.xx.xxx version
   FTL_VERSION="$(echo "${FTL_VERSION}" | grep -oE '^v[0-9]+([.][0-9]+){1,2}')"
   if [ "${FTL_BRANCH}" = "master" ]; then
-    if [ "${FTL_HASH}" = "${GITHUB_FTL_HASH}" ]; then
-        # up-to-date
-        ftl_version_heatmap=${green_text}
-      else
-        #out-of-date
-        out_of_date_flag="true"
-        ftl_version_heatmap=${red_text}
-      fi
+    ftl_version_converted="$(VersionConverter "${FTL_VERSION}")"
+    ftl_version_latest_converted=$(VersionConverter "${GITHUB_FTL_VERSION}")
+
+    if [ "${ftl_version_converted}" -lt "${ftl_version_latest_converted}" ]; then
+      out_of_date_flag="true"
+      ftl_version_heatmap=${red_text}
+    else
+      ftl_version_heatmap=${green_text}
+    fi
   else
     # Custom branch
     if [ -z "${FTL_BRANCH}"  ]; then
@@ -541,7 +560,14 @@ GetVersionInformation() {
       ftl_version_heatmap=${red_text}
       FTL_VERSION="?"
     else
-      ftl_version_heatmap=${yellow_text}
+      if [ "${FTL_HASH}" = "${GITHUB_FTL_HASH}" ]; then
+        # up-to-date
+        ftl_version_heatmap=${green_text}
+      else
+        # out-of-date
+        out_of_date_flag="true"
+        ftl_version_heatmap=${red_text}
+      fi
       # shorten common branch names (fix/, tweak/, new/)
       # use the first 7 characters of the branch name as version
       FTL_VERSION="$(printf '%s' "$FTL_BRANCH" | sed 's/fix\//f\//;s/new\//n\//;s/tweak\//t\//' | cut -c 1-7)"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

With PR https://github.com/pi-hole/PADD/pull/274 we started using `/etc/pihole/versions` to determine if updates are available. We therefore compare the local and remote hash of the last commit on `master`. However, we didn't take into account that we do not tag every push to master (e.g. internal PRs that change workflows) as a new version. In `core` we reset the local repo to the lastest tag https://github.com/pi-hole/pi-hole/blob/c32761e7864b9fa29c1a22def2b1c3698c609d79/automated%20install/basic-install.sh#L440 to not trigger local updates without a new tag.

`PADD` should behave the same and should not report updates which users can't reach with `pihole -up`.

This PR omits the hashes for `master` branch and falls-back to `tags` extracted from the local and remote `version`.
Additionally, it moves the hash comparison into the realm of the `custom` branches to inform users if the use the latest code of a custom branch.
___

Example `versions` file

```
CORE_BRANCH=development
WEB_BRANCH=master
FTL_BRANCH=development
CORE_VERSION=v5.14.2-23-g7971cf0a
WEB_VERSION=v5.17-2-ga8164201
FTL_VERSION=vDev-ffea21e
GITHUB_CORE_VERSION=v5.14.2
GITHUB_WEB_VERSION=v5.17
CORE_HASH=7971cf0a
GITHUB_CORE_HASH=619cebb6
WEB_HASH=a8164201
GITHUB_WEB_HASH=a8164201
FTL_HASH=ffea21e6
GITHUB_FTL_HASH=ffea21e6
GITHUB_FTL_VERSION=v5.19.2

```

and corresponding `PADD` screen

![Screenshot at 2022-12-17 21-36-12](https://user-images.githubusercontent.com/26622301/208265416-05845cca-c1db-4a24-9680-d3f0381115cb.png)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
