### PR TITLE
Fix check if FTL is running

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -400,7 +400,8 @@ GetPiholeInformation() {
   # Get FTL status
   ftlPID=$(pidof pihole-FTL)
 
-  if [ -z ${ftlPID+x} ]; then
+  # If FTL is not running, set all variables to "not running"
+  if [ -z "${ftlPID}" ]; then
     ftl_status="Not running"
     ftl_heatmap=${yellow_text}
     ftl_check_box=${check_box_info}
@@ -413,6 +414,7 @@ GetPiholeInformation() {
     ftl_status="Running"
     ftl_heatmap=${green_text}
     ftl_check_box=${check_box_good}
+    # Get FTL CPU and memory usage
     ftl_cpu="$(ps -p "${ftlPID}" -o %cpu | tail -n1 | tr -d '[:space:]')"
     ftl_mem_percentage="$(ps -p "${ftlPID}" -o %mem | tail -n1 | tr -d '[:space:]')"
   fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix #303 

**How does this PR accomplish the above?:**

The currently used test is broken:

``` bash
if [ -z ${ftlPID+x} ]; then
```
will *always* succeed as `+x` will substitute the variable by `x` if the variable is set.

As we have
```
ftlPID=$(pidof pihole-FTL)
```
above, the variable will never be unset. However, when FTL ist not running and the variable is empty, the substitution will kick in and the test will still succeed (although it obviously shouldn't). This test is simply wrong.

The test should read
``` bash
if [ -z "${ftlPID}" ]; then
```
instead.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
