### PR TITLE
Don't use zero to signal failure

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -119,8 +119,6 @@ GetFTLData() {
       # Send command to FTL and ask to quit when finished
       data="$(echo ">$1 >quit" | nc 127.0.0.1 "${ftl_port}")"
       echo "${data}"
-    else
-      echo "0"
     fi
 }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We use `GetFTLData "dns-port"` to figure out the DNS port `FTL` is listening on.

https://github.com/pi-hole/PADD/blob/1cf30ee904fb7501eb1ac98f56bd833a25496275/padd.sh#L423

 This port can be `0` if the DNS function of the internal `dnsmasq` is disabled. (https://docs.pi-hole.net/ftldns/telnet-api/#dns-port)


However, we use `0` within `GetFTLData()`, to signal an error when we fail to get the telnet API port (for whatever reason)

https://github.com/pi-hole/PADD/blob/1cf30ee904fb7501eb1ac98f56bd833a25496275/padd.sh#L114-L124

We should not use a number as return code that could have another meaning. As `GetFTLData "dns-port"` is the only place we actually checked for `0` (read as: we never checked anywhere else) I removed the code to signal a failure on getting the API port.

Issue discovered in https://github.com/pi-hole/PADD/issues/307. (This PR won't fix the issue, but can help to improve investigation)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
