### PR TITLE
Use `getFTLPID` instead of `pidof`

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -393,7 +393,7 @@ GetNetworkInformation() {
 
 GetPiholeInformation() {
   # Get FTL status
-  ftlPID=$(pidof pihole-FTL)
+  ftlPID=$(ps h -C pihole-FTL -o %p)
 
   # If FTL is not running, set all variables to "not running"
   ftl_down_flag=false
@@ -408,8 +408,8 @@ GetPiholeInformation() {
     ftl_heatmap=${green_text}
     ftl_check_box=${check_box_good}
     # Get FTL CPU and memory usage
-    ftl_cpu="$(ps -p "${ftlPID}" -o %cpu | tail -n1 | tr -d '[:space:]')"
-    ftl_mem_percentage="$(ps -p "${ftlPID}" -o %mem | tail -n1 | tr -d '[:space:]')"
+    ftl_cpu="$(ps h -C pihole-FTL -o %cpu | tr -d '[:space:]')"
+    ftl_mem_percentage="$(ps h -C pihole-FTL -o %mem | tr -d '[:space:]')"
     # Get Pi-hole (blocking) status
     ftl_dns_port=$(GetFTLData "dns-port")
   fi

--- a/padd.sh
+++ b/padd.sh
@@ -405,13 +405,15 @@ GetPiholeInformation() {
     ftl_check_box=${check_box_info}
     # set flag to change the status message in SetStatusMessage()
     ftl_down_flag=true
+    ftl_cpu="N/A"
+    ftl_mem_percentage="N/A"
   else
     ftl_status="Running"
     ftl_heatmap=${green_text}
     ftl_check_box=${check_box_good}
     # Get FTL CPU and memory usage
-    ftl_cpu="$(ps h -p "${ftlPID}" -o %cpu | tr -d '[:space:]')"
-    ftl_mem_percentage="$(ps h -p "${ftlPID}" -o %mem | tr -d '[:space:]')"
+    ftl_cpu="$(ps h -p "${ftlPID}" -o %cpu | tr -d '[:space:]')%"
+    ftl_mem_percentage="$(ps h -p "${ftlPID}" -o %mem | tr -d '[:space:]')%"
     # Get Pi-hole (blocking) status
     ftl_dns_port=$(GetFTLData "dns-port")
   fi
@@ -896,7 +898,7 @@ PrintDashboard() {
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Top Dmn:" "${top_domain}"
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Top Clnt:" "${top_client}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}FTL ===========================================================================${reset_text}"
-        moveXOffset; printf " %-10s%-9s %-10s%-9s %-10s%-9s${clear_line}\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}%" "Mem. Use:" "${ftl_mem_percentage}%"
+        moveXOffset; printf " %-10s%-9s %-10s%-9s %-10s%-9s${clear_line}\n" "PID:" "${ftlPID}" "CPU Use:" "${ftl_cpu}" "Mem. Use:" "${ftl_mem_percentage}"
         moveXOffset; printf " %-10s%-69s${clear_line}\n" "DNSCache:" "${cache_inserts} insertions, ${cache_deletes} deletions, ${cache_size} total entries"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK =======================================================================${reset_text}"
         moveXOffset; printf " %-10s%-19s${clear_line}\n" "Hostname:" "${full_hostname}"

--- a/padd.sh
+++ b/padd.sh
@@ -397,9 +397,9 @@ GetPiholeInformation() {
   # Get FTL's current PID
   ftlPID="$(getFTLPID)"
 
-  # If FTL is not running, set all variables to "not running"
+  # If FTL is not running (getFTLPID returns -1), set all variables to "not running"
   ftl_down_flag=false
-  if [ -z "${ftlPID}" ]; then
+  if [ "${ftlPID}" = "-1" ]; then
     ftl_status="Not running"
     ftl_heatmap=${yellow_text}
     ftl_check_box=${check_box_info}

--- a/padd.sh
+++ b/padd.sh
@@ -393,7 +393,9 @@ GetNetworkInformation() {
 
 GetPiholeInformation() {
   # Get FTL status
-  ftlPID=$(ps h -C pihole-FTL -o %p)
+
+  # Get FTL's current PID
+  ftlPID="$(getFTLPID)"
 
   # If FTL is not running, set all variables to "not running"
   ftl_down_flag=false
@@ -408,8 +410,8 @@ GetPiholeInformation() {
     ftl_heatmap=${green_text}
     ftl_check_box=${check_box_good}
     # Get FTL CPU and memory usage
-    ftl_cpu="$(ps h -C pihole-FTL -o %cpu | tr -d '[:space:]')"
-    ftl_mem_percentage="$(ps h -C pihole-FTL -o %mem | tr -d '[:space:]')"
+    ftl_cpu="$(ps h -p "${ftlPID}" -o %cpu | tr -d '[:space:]')"
+    ftl_mem_percentage="$(ps h -p "${ftlPID}" -o %mem | tr -d '[:space:]')"
     # Get Pi-hole (blocking) status
     ftl_dns_port=$(GetFTLData "dns-port")
   fi
@@ -1085,6 +1087,37 @@ getFTLAPIPort(){
     echo "${ftl_api_port}"
 
 }
+
+# returns FTL's PID based on the content of the pihole-FTL.pid file
+# honor PIDFILE setting in `pihole-FTL.conf`
+getFTLPID() {
+    local FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
+    local DEFAULT_PID_FILE="/run/pihole-FTL.pid"
+    local FTL_PID_FILE
+    local FTL_PID
+
+    if [ -s "${FTLCONFFILE}" ]; then
+      # if PIDFILE is not set in pihole-FTL.conf, use the default path
+      FTL_PID_FILE="$({ grep '^PIDFILE=' "${FTLCONFFILE}" || echo "${DEFAULT_PID_FILE}"; } | cut -d'=' -f2-)"
+    else
+      # if there is no pihole-FTL.conf, use the default path
+      FTL_PID_FILE="${DEFAULT_PID_FILE}"
+    fi
+
+    if [ -s "${FTL_PID_FILE}" ]; then
+        # -s: FILE exists and has a size greater than zero
+        FTL_PID="$(cat "${FTL_PID_FILE}")"
+        # Exploit prevention: unset the variable if there is malicious content
+        # Verify that the value read from the file is numeric
+        expr "${FTL_PID}" : "[^[:digit:]]" > /dev/null && unset FTL_PID
+    fi
+
+    # If FTL is not running, or the PID file contains malicious stuff, substitute
+    # negative PID to signal this
+    FTL_PID=${FTL_PID:=-1}
+    echo  "${FTL_PID}"
+}
+
 
 moveYOffset(){
     # moves the cursor yOffset-times down


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Currently, we use `pidof` to test if `FTL` is running. However, there are hints that `pidof` might be a bit unreliable to find all processes. See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=926896 and https://unix.stackexchange.com/questions/518411/why-is-pidof-not-working

This as also been reported in one of our issues: https://github.com/pi-hole/PADD/issues/307#issuecomment-1364536411

**How does this PR accomplish the above?:**

1) Replacing `pidof` with `getFTLPID`, a function that we also use in `core`. It'll read the `PID` from `pihole-FTL.pid` file `FTL` writes on it's start.
2) Additionally, this PR adds the `h` option to the `ps` command for getting `FTL`s CPU and memory utilization to save one pipe to `tail`.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
