### PR TITLE
Add version bump workflow

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,0 +1,49 @@
+name: Version bump
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.repository }}
+      GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    steps:
+      - name: Get latest release tag # can also be a draft release
+        run: |
+          LATEST_TAG=$(gh -R $REPO release list -L 1 | awk '{printf $3}')
+          echo "Latest version tag for releases in $REPO is $LATEST_TAG"
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v3.2.0
+        with:
+          ref: 'development'
+
+      - name: Check if branch already exists
+        run: |
+          LATEST_TAG=${{ env.latest_tag }}
+          REMOTE_BRANCH=$(git ls-remote --heads origin "bump_$LATEST_TAG")
+          [[ -z ${REMOTE_BRANCH} ]] && echo "branch_exists=false" >> $GITHUB_ENV || echo "branch_exists=true" >> $GITHUB_ENV
+          [[ -z ${REMOTE_BRANCH} ]] && echo "Remote branch bump_$LATEST_TAG does not exist" || echo "Remote branch bump_$LATEST_TAG already exists"
+
+      - name: Get current version
+        run: |
+          CURRENT_VERSION=$(cat padd.sh | grep '^padd_version=' | cut -d'"' -f 2)
+          echo "Current PADD version is $CURRENT_VERSION"
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_ENV
+
+      - name: Create PR if versions don't match and branch does not exist
+        if: (env.current_version != env.latest_tag) && (env.branch_exists == 'false')
+        run: |
+          LATEST_TAG=${{ env.latest_tag }}
+          git config --global user.email "pralor-bot@users.noreply.github.com"
+          git config --global user.name "pralor-bot"
+          git checkout -b "bump_$LATEST_TAG" development
+          sed -i "s/^padd_version=.*/padd_version=\"$LATEST_TAG\"/" padd.sh
+          git commit -a -m "Bump version to $LATEST_TAG"
+          git push --set-upstream origin "bump_$LATEST_TAG"
+          gh pr create -B development -H "bump_$LATEST_TAG" --title "Bump version to ${LATEST_TAG}" --body 'Created by Github action' --label 'Internal'


### PR DESCRIPTION
**PR Master branch**

**What does this PR aim to accomplish?:**

Re-do of https://github.com/pi-hole/PADD/pull/195.

Currently, we need to manually bump the version inside `padd.sh` for each release. This workflow allows to create a version bump PR automatically, if we draft a new release with a new tag. The workflow will run every hour or is triggered manually. It checks the latest tag a release has on github (includes drafts), and if the string differs from the current one set in `development` and a branch named `bump_$latest_tag` does not exist it files a PR.

See those PRs for example: https://github.com/yubiuser/PADD/pull/17, https://github.com/yubiuser/PADD/pull/18, https://github.com/yubiuser/PADD/pull/19

The idea behind this workflow is laid out here: https://github.com/pi-hole/PADD/pull/195#issuecomment-1207971448


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
