### PR TITLE
Export LOCALE

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -9,11 +9,8 @@
 # A more advanced version of the chronometer provided with Pihole
 
 # SETS LOCALE
-# Issue 5: https://github.com/jpmck/PADD/issues/5
-# Updated to en_US to support
-# export LC_ALL=en_US.UTF-8 > /dev/null 2>&1 || export LC_ALL=en_GB.UTF-8 > /dev/null 2>&1 || export LC_ALL=C.UTF-8 > /dev/null 2>&1
-LC_ALL=C
-LC_NUMERIC=C
+export LC_ALL=C
+export LC_NUMERIC=C
 
 ############################################ VARIABLES #############################################
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Exports the set `LOCALE` so subshells can inherit this setting. Otherwise, subshells will fall back to the system's default `LOCALE` which can break `PADD` in a few places if users language uses different separators for numbers.

Fixes https://github.com/pi-hole/PADD/issues/334#issuecomment-1386060054

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
