### PR TITLE
Add version function to PADD

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -1205,7 +1205,7 @@ ShowVersion() {
   if [ -n "${DOCKER_VERSION}" ]; then
     # Check for latest Docker version
     GetVersionInformation
-    printf "%s${clear_line}\n" "  PADD version is ${padd_version}$ as part of Docker ${docker_version_heatmap}${DOCKER_VERSION}${reset_text} (Latest Docker: ${GITHUB_DOCKER_VERSION})"
+    printf "%s${clear_line}\n" "  PADD version is ${padd_version} as part of Docker ${docker_version_heatmap}${DOCKER_VERSION}${reset_text} (Latest Docker: ${GITHUB_DOCKER_VERSION})"
     version_info="Docker ${docker_version_heatmap}${DOCKER_VERSION}${reset_text}"
   else
     printf "%s${clear_line}\n" "  PADD version is ${padd_version_heatmap}${padd_version}${reset_text} (Latest: ${padd_version_latest})"
@@ -1398,6 +1398,7 @@ DisplayHelp() {
 :::  -xoff [num]    set the x-offset, reference is the upper left corner, disables auto-centering
 :::  -yoff [num]    set the y-offset, reference is the upper left corner, disables auto-centering
 :::  -j, --json     output stats as JSON formatted string and exit
+:::  -v, --version  show PADD version info
 :::  -h, --help     display this help text
 
 EOM

--- a/padd.sh
+++ b/padd.sh
@@ -1195,6 +1195,23 @@ OutputJSON() {
   echo "{\"domains_being_blocked\":${domains_being_blocked_raw},\"dns_queries_today\":${dns_queries_today_raw},\"ads_blocked_today\":${ads_blocked_today_raw},\"ads_percentage_today\":${ads_percentage_today_raw},\"clients\": ${clients}}"
 }
 
+ShowVersion() {
+  # source version file to check if $DOCKER_VERSION is set
+  . /etc/pihole/versions
+  GetPADDInformation
+  if [ -z "${padd_version_latest}" ]; then
+    padd_version_latest="N/A"
+  fi
+  if [ -n "${DOCKER_VERSION}" ]; then
+    # Check for latest Docker version
+    GetVersionInformation
+    printf "%s${clear_line}\n" "  PADD version is ${padd_version}$ as part of Docker ${docker_version_heatmap}${DOCKER_VERSION}${reset_text} (Latest Docker: ${GITHUB_DOCKER_VERSION})"
+    version_info="Docker ${docker_version_heatmap}${DOCKER_VERSION}${reset_text}"
+  else
+    printf "%s${clear_line}\n" "  PADD version is ${padd_version_heatmap}${padd_version}${reset_text} (Latest: ${padd_version_latest})"
+  fi
+}
+
 StartupRoutine(){
   # Get config variables
   . /etc/pihole/setupVars.conf
@@ -1384,7 +1401,6 @@ DisplayHelp() {
 :::  -h, --help     display this help text
 
 EOM
-    exit 0
 }
 
 CleanExit(){
@@ -1449,6 +1465,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     "-j" | "--json"     ) OutputJSON; exit 0;;
     "-h" | "--help"     ) DisplayHelp; exit 0;;
+    "-v" | "--version"  ) ShowVersion; exit 0;;
     "-xoff"             ) xOffset="$2"; xOffOrig="$2"; shift;;
     "-yoff"             ) yOffset="$2"; yOffOrig="$2"; shift;;
     *                   ) DisplayHelp; exit 1;;


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Adds a `-v/--version`option to `padd.sh` to print the current/latest PADD version.

```
pi@s740:~$ ./padd.sh --version
  PADD version is v3.10 (Latest: v3.10.1) 
```

**How does this PR accomplish the above?:**

Re-use existing `GetPADDInformation()` and `GetVersionInformation)=`

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
