### PR TITLE
When running locally derive port from FTL itself

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -104,6 +104,9 @@ ConstructAPI() {
 	# If no arguments were supplied set them to default
 	if [ -z "${URL}" ]; then
 		URL=127.0.0.1
+        # when no $URL is set we assume PADD is running locally and we can get the port value from FTL directly
+        PORT="$(pihole-FTL  --config webserver.port)"
+        PORT="${PORT%%,*}"
 	fi
 	if [ -z "${PORT}" ]; then
 		PORT=80
@@ -1231,7 +1234,7 @@ secretRead() {
     # `-n` option (reading n chars)
 
 
-    # This workaround changes the terminal characteristics to not echo input and later rests this option
+    # This workaround changes the terminal characteristics to not echo input and later resets this option
     # credits https://stackoverflow.com/a/4316765
     # showing astrix instead of password
     # https://stackoverflow.com/a/24600839

--- a/padd.sh
+++ b/padd.sh
@@ -105,7 +105,7 @@ ConstructAPI() {
 	if [ -z "${URL}" ]; then
 		URL=127.0.0.1
         # when no $URL is set we assume PADD is running locally and we can get the port value from FTL directly
-        PORT="$(pihole-FTL  --config webserver.port)"
+        PORT="$(pihole-FTL --config webserver.port)"
         PORT="${PORT%%,*}"
 	fi
 	if [ -z "${PORT}" ]; then


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

If n `$URL` is supplied, we assume we run PADD on the same host as `FTL` so we can use `FTL` to tell us the port we need to use. Saves users from using `--port PORT` locally.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
