### PR TITLE
Use `unset` to reset CPU temp variable on each iteration

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -160,6 +160,9 @@ GetSystemInformation() {
   # System uptime
     system_uptime_raw=$(uptime)
 
+  # reset $cpu variable
+  unset cpu
+
   # CPU temperature
   if [ -d "/sys/devices/platform/coretemp.0/hwmon/" ]; then
     cpu=$(cat "$(find /sys/devices/platform/coretemp.0/hwmon/ -maxdepth 2 -name "temp1_input" 2>/dev/null | head -1)" 2>/dev/null)


### PR DESCRIPTION
### What does this PR aim to accomplish?

[Fix #368](https://github.com/pi-hole/PADD/issues/368)

### How does this PR accomplish the above?

Resetting the `$cpu` variable between calls.  

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
