### PR TITLE
Exit bump workflow early if latest tag is empty

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -17,6 +17,7 @@ jobs:
           LATEST_TAG=$(gh -R $REPO release list -L 1 | awk '{printf $3}')
           echo "Latest version tag for releases in $REPO is $LATEST_TAG"
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
+          [[ -z ${LATEST_TAG} ]] && echo "Error: LATEST_TAG is empty, aborting" && exit 1
 
       - name: Checkout code
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
Fixes the `bump` workflow. Currently, if connectivity issues arise `LATEST_TAG` might be empty (seen https://github.com/pi-hole/PADD/actions/runs/9770802529/job/26972556103) which will create nonsense `bump` PRs like https://github.com/pi-hole/PADD/pull/393

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
