### PR TITLE
Suppress curl and floating number conversion

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -232,7 +232,7 @@ DeleteSession() {
 }
 
 Authenticate() {
-	sessionResponse="$(curl -sk -X POST "${API_URL}auth" --user-agent "PADD ${padd_version}" --data "{\"password\":\"${password}\"}" )"
+  sessionResponse="$(curl -sk -X POST "${API_URL}auth" --user-agent "PADD ${padd_version}" --data "{\"password\":\"${password}\"}" )"
 
   if [ -z "${sessionResponse}" ]; then
     moveXOffset; echo "No response from FTL server. Please check connectivity and use the options to set the API URL"
@@ -247,7 +247,7 @@ Authenticate() {
 GetFTLData() {
   local response
   # get the data from querying the API as well as the http status code
-	response=$(curl -sk -w "%{http_code}" -X GET "${API_URL}$1" -H "Accept: application/json" -H "sid: ${SID}" )
+  response=$(curl -sk -w "%{http_code}" -X GET "${API_URL}$1" -H "Accept: application/json" -H "sid: ${SID}" )
 
   # status are the last 3 characters
   status=$(printf %s "${response#"${response%???}"}")

--- a/padd.sh
+++ b/padd.sh
@@ -137,7 +137,7 @@ TestAPIAvailability() {
         API_URL="${API_URL#\"}"
 
         # Test if the API is available at this URL
-        availabilityResponse=$(curl -skS -o /dev/null -w "%{http_code}" "${API_URL}auth")
+        availabilityResponse=$(curl -sk -o /dev/null -w "%{http_code}" "${API_URL}auth")
 
         # Test if http status code was 200 (OK) or 401 (authentication required)
         if [ ! "${availabilityResponse}" = 200 ] && [ ! "${availabilityResponse}" = 401 ]; then
@@ -217,7 +217,7 @@ DeleteSession() {
     # SID is not null (successful authenthication only), delete the session
     if [ "${validSession}" = true ] && [ ! "${SID}" = null ]; then
         # Try to delete the session. Omit the output, but get the http status code
-        deleteResponse=$(curl -skS -o /dev/null -w "%{http_code}" -X DELETE "${API_URL}auth"  -H "Accept: application/json" -H "sid: ${SID}")
+        deleteResponse=$(curl -sk -o /dev/null -w "%{http_code}" -X DELETE "${API_URL}auth"  -H "Accept: application/json" -H "sid: ${SID}")
 
         printf "\n\n"
         case "${deleteResponse}" in
@@ -232,7 +232,7 @@ DeleteSession() {
 }
 
 Authenticate() {
-  sessionResponse="$(curl -skS -X POST "${API_URL}auth" --user-agent "PADD ${padd_version}" --data "{\"password\":\"${password}\"}" )"
+	sessionResponse="$(curl -sk -X POST "${API_URL}auth" --user-agent "PADD ${padd_version}" --data "{\"password\":\"${password}\"}" )"
 
   if [ -z "${sessionResponse}" ]; then
     moveXOffset; echo "No response from FTL server. Please check connectivity and use the options to set the API URL"
@@ -247,7 +247,7 @@ Authenticate() {
 GetFTLData() {
   local response
   # get the data from querying the API as well as the http status code
-  response=$(curl -skS -w "%{http_code}" -X GET "${API_URL}$1" -H "Accept: application/json" -H "sid: ${SID}" )
+	response=$(curl -sk -w "%{http_code}" -X GET "${API_URL}$1" -H "Accept: application/json" -H "sid: ${SID}" )
 
   # status are the last 3 characters
   status=$(printf %s "${response#"${response%???}"}")
@@ -1634,7 +1634,7 @@ Update() {
 
         echo "${check_box_info} Downloading PADD update ..."
 
-        if  curl -sSL https://install.padd.sh -o "${padd_script_path}" > /dev/null 2>&1; then
+        if  curl -sL https://install.padd.sh -o "${padd_script_path}" > /dev/null 2>&1; then
             echo "${check_box_good} ... done. Restart PADD for the update to take effect"
         else
             echo "${check_box_bad} Cannot download PADD update"

--- a/padd.sh
+++ b/padd.sh
@@ -279,17 +279,32 @@ GetSummaryInformation() {
   blocking_enabled=$(echo "${dns_blocking}" | jq .blocking 2>/dev/null)
 
   domains_being_blocked_raw=$(echo "${ftl_info}" | jq .ftl.database.gravity 2>/dev/null)
-  domains_being_blocked=$(printf "%.f" "${domains_being_blocked_raw}")
+  if [ -z "${domains_being_blocked_raw}" ]; then
+    domains_being_blocked="N/A"
+  else
+    domains_being_blocked=$(printf "%.f" "${domains_being_blocked_raw}")
+  fi
 
   dns_queries_today_raw=$(echo "$summary" | jq .queries.total 2>/dev/null)
-  dns_queries_today=$(printf "%.f" "${dns_queries_today_raw}")
+  if [ -z "${dns_queries_today_raw}" ]; then
+    dns_queries_today="N/A"
+  else
+    dns_queries_today=$(printf "%.f" "${dns_queries_today_raw}")
+  fi
 
   ads_blocked_today_raw=$(echo "$summary" | jq .queries.blocked 2>/dev/null)
-  ads_blocked_today=$(printf "%.f" "${ads_blocked_today_raw}")
+  if [ -z "${ads_blocked_today_raw}" ]; then
+    ads_blocked_today="N/A"
+  else
+    ads_blocked_today=$(printf "%.f" "${ads_blocked_today_raw}")
+  fi
 
   ads_percentage_today_raw=$(echo "$summary" | jq .queries.percent_blocked 2>/dev/null)
-  ads_percentage_today=$(printf "%.1f" "${ads_percentage_today_raw}")
-
+  if [ -z "${ads_percentage_today_raw}" ]; then
+    ads_percentage_today="N/A"
+  else
+    ads_percentage_today=$(printf "%.1f" "${ads_percentage_today_raw}")
+  fi
   cache_size=$(echo "$cache_info" | jq .metrics.dns.cache.size 2>/dev/null)
   cache_evictions=$(echo "$cache_info" | jq .metrics.dns.cache.evicted 2>/dev/null)
   cache_inserts=$(echo "$cache_info"| jq .metrics.dns.cache.inserted 2>/dev/null)
@@ -515,12 +530,20 @@ GetNetworkInformation() {
     # Default interface data (use IPv4 interface - we cannot show both and assume they are the same)
     iface_name="${gateway_v4_iface}"
     tx_bytes="$(echo "${v4_iface_data}" | jq --raw-output '.stats.tx_bytes.value' 2>/dev/null)"
-    tx_bytes_unit="$(echo "${v4_iface_data}" | jq --raw-output '.stats.tx_bytes.unit' 2>/dev/null)"
-    tx_bytes=$(printf "%.1f %b" "${tx_bytes}" "${tx_bytes_unit}")
+    if [ -z "${tx_bytes}" ]; then
+        tx_bytes="N/A"
+    else
+        tx_bytes_unit="$(echo "${v4_iface_data}" | jq --raw-output '.stats.tx_bytes.unit' 2>/dev/null)"
+        tx_bytes=$(printf "%.1f %b" "${tx_bytes}" "${tx_bytes_unit}")
+    fi
 
     rx_bytes="$(echo "${v4_iface_data}" | jq --raw-output '.stats.rx_bytes.value' 2>/dev/null)"
-    rx_bytes_unit="$(echo "${v4_iface_data}" | jq --raw-output '.stats.rx_bytes.unit' 2>/dev/null)"
-    rx_bytes=$(printf "%.1f %b" "${rx_bytes}" "${rx_bytes_unit}")
+    if [ -z "${rx_bytes}" ]; then
+        rx_bytes="N/A"
+    else
+        rx_bytes_unit="$(echo "${v4_iface_data}" | jq --raw-output '.stats.rx_bytes.unit' 2>/dev/null)"
+        rx_bytes=$(printf "%.1f %b" "${rx_bytes}" "${rx_bytes_unit}")
+    fi
 
     # If IPv4 and IPv6 interfaces are not the same, add a "*" to the interface
     # name to highlight that there are two different interfaces and the
@@ -551,8 +574,16 @@ GetPiholeInformation() {
     # Get FTL CPU and memory usage
     ftl_cpu_raw="$(echo "${sysinfo}" | jq '.ftl."%cpu"' 2>/dev/null)"
     ftl_mem_percentage_raw="$(echo "${sysinfo}" | jq '.ftl."%mem"' 2>/dev/null)"
-    ftl_cpu="$(printf "%.1f" "${ftl_cpu_raw}")%"
-    ftl_mem_percentage="$(printf "%.1f" "${ftl_mem_percentage_raw}")%"
+    if [ -z "${ftl_cpu_raw}" ]; then
+      ftl_cpu="N/A"
+    else
+      ftl_cpu="$(printf "%.1f" "${ftl_cpu_raw}")%"
+    fi
+    if [ -z "${ftl_mem_percentage_raw}" ]; then
+      ftl_mem_percentage="N/A"
+    else
+      ftl_mem_percentage="$(printf "%.1f" "${ftl_mem_percentage_raw}")%"
+    fi
     # Get Pi-hole (blocking) status
     ftl_dns_port=$(GetFTLData "config" | jq .config.dns.port 2>/dev/null)
     # Get FTL's current PID


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

During rare circumstances (FTL restart and PADD data request) `curl` could fail and output error text in the unused `x/y-offset` margins. As this area is not cleared by default (to avoid flickering) the error text remains. 

This PR removes the `-S, --show-error` flag from `curl` calls to prevent any error output.

Additionally, it guards floating number conversions incase the input is empty.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
