### PR TITLE
Tweak disabled color

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -528,12 +528,12 @@ GetNetworkInformation() {
             dhcp_ipv6_check_box=${check_box_good}
         else
             dhcp_ipv6_status="Disabled"
-            dhcp_ipv6_heatmap=${red_text}
+            dhcp_ipv6_heatmap=${blue_text}
             dhcp_ipv6_check_box=${check_box_bad}
         fi
     else
         dhcp_status="Disabled"
-        dhcp_heatmap=${red_text}
+        dhcp_heatmap=${blue_text}
         dhcp_check_box=${check_box_bad}
 
         # Display the gateway address if DHCP is disabled
@@ -576,7 +576,7 @@ GetNetworkInformation() {
         dnssec_heatmap=${green_text}
     else
         dnssec_status="Disabled"
-        dnssec_heatmap=${red_text}
+        dnssec_heatmap=${blue_text}
     fi
 
     # Conditional forwarding
@@ -586,7 +586,7 @@ GetNetworkInformation() {
         conditional_forwarding_heatmap=${green_text}
     else
         conditional_forwarding_status="Disabled"
-        conditional_forwarding_heatmap=${red_text}
+        conditional_forwarding_heatmap=${blue_text}
     fi
 
     # Default interface data (use IPv4 interface - we cannot show both and assume they are the same)

--- a/padd.sh
+++ b/padd.sh
@@ -44,6 +44,7 @@ dim_text="${CSI}2m"
 # CHECK BOXES
 check_box_good="[${green_text}✓${reset_text}]"       # Good
 check_box_bad="[${red_text}✗${reset_text}]"          # Bad
+check_box_disabled="[${blue_text}-${reset_text}]"    # Disabled, but not an error
 check_box_question="[${yellow_text}?${reset_text}]"  # Question / ?
 check_box_info="[${yellow_text}i${reset_text}]"      # Info / i
 
@@ -529,12 +530,12 @@ GetNetworkInformation() {
         else
             dhcp_ipv6_status="Disabled"
             dhcp_ipv6_heatmap=${blue_text}
-            dhcp_ipv6_check_box=${check_box_bad}
+            dhcp_ipv6_check_box=${check_box_disabled}
         fi
     else
         dhcp_status="Disabled"
         dhcp_heatmap=${blue_text}
-        dhcp_check_box=${check_box_bad}
+        dhcp_check_box=${check_box_disabled}
 
         # Display the gateway address if DHCP is disabled
         GATEWAY="$(GetPADDValue iface.v4.gw_addr | head -n 1)"


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix https://github.com/pi-hole/PADD/issues/64

DHCP and DNSSEC options are shown in red when disabled, the red color gives the impression of an error state. In some cases, disabled is only representing "not in use" and it could be a desirable state.

### How does this PR accomplish the above?

Using blue color:

![image](https://github.com/user-attachments/assets/3a7d47a6-efac-4871-91df-1705ed02937d)

Also replacing the red "bad/error" box, with a new "disabled box" in small sizes:

![image](https://github.com/user-attachments/assets/149a2269-5364-4c99-a1df-8ae3b110fc91)


<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*
