### PR TITLE
Improve DHCP and IPv6 info

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -1573,7 +1573,7 @@ StartupRoutine(){
       moveXOffset; echo "  - Docker Tag ${DOCKER_VERSION}"
     else
       moveXOffset; echo "  - Core $CORE_VERSION, Web $WEB_VERSION"
-      moveXOffset; echo "  - FTL $FTL_VERSION, PADD ${padd_data}_version"
+      moveXOffset; echo "  - FTL $FTL_VERSION, PADD ${padd_version}"
     fi
 
   else

--- a/padd.sh
+++ b/padd.sh
@@ -501,9 +501,9 @@ GetNetworkInformation() {
     if [ "${pi_ip6_addrs}" -eq 0 ]; then
         # No IPv6 address available
         pi_ip6_addr="N/A"
-        ipv6_check_box=${check_box_bad}
+        ipv6_check_box=${check_box_disabled}
         ipv6_status="Disabled"
-        ipv6_heatmap=${red_text}
+        ipv6_heatmap=${blue_text}
     elif [ "${pi_ip6_addrs}" -eq 1 ]; then
         # One IPv6 address available
         ipv6_check_box=${check_box_good}

--- a/padd.sh
+++ b/padd.sh
@@ -451,14 +451,16 @@ GetNetworkInformation() {
         iface_name="N/A"
         pi_ip4_addr="N/A"
         pi_ip6_addr="N/A"
+        ipv6_status="N/A"
+        ipv6_heatmap=${reset_text}
         ipv6_check_box=${check_box_question}
 
         dhcp_status="N/A"
         dhcp_heatmap=${reset_text}
-        dhcp_info=""
+        dhcp_range="N/A"
+        dhcp_range_heatmap=${reset_text}
         dhcp_ipv6_status="N/A"
         dhcp_ipv6_heatmap=${reset_text}
-        dhcp_ipv6_check_box=${check_box_question}
 
         pi_hostname="N/A"
         full_hostname="N/A"
@@ -500,13 +502,19 @@ GetNetworkInformation() {
         # No IPv6 address available
         pi_ip6_addr="N/A"
         ipv6_check_box=${check_box_bad}
+        ipv6_status="Disabled"
+        ipv6_heatmap=${red_text}
     elif [ "${pi_ip6_addrs}" -eq 1 ]; then
         # One IPv6 address available
         ipv6_check_box=${check_box_good}
+        ipv6_status="Enabled"
+        ipv6_heatmap=${green_text}
     else
         # More than one IPv6 address available
         pi_ip6_addr="${pi_ip6_addr}+"
         ipv6_check_box=${check_box_good}
+        ipv6_status="Enabled"
+        ipv6_heatmap=${green_text}
     fi
 
     # Is Pi-Hole acting as the DHCP server?
@@ -517,7 +525,8 @@ GetNetworkInformation() {
         DHCP_END="$(GetPADDValue config.dhcp_end)"
 
         dhcp_status="Enabled"
-        dhcp_info=" Range:    ${DHCP_START} - ${DHCP_END}"
+        dhcp_range="${DHCP_START} - ${DHCP_END}"
+        dhcp_range_heatmap=${reset_text}
         dhcp_heatmap=${green_text}
         dhcp_check_box=${check_box_good}
 
@@ -526,23 +535,19 @@ GetNetworkInformation() {
         if [ "${DHCP_IPv6}" = "true" ]; then
             dhcp_ipv6_status="Enabled"
             dhcp_ipv6_heatmap=${green_text}
-            dhcp_ipv6_check_box=${check_box_good}
         else
             dhcp_ipv6_status="Disabled"
             dhcp_ipv6_heatmap=${blue_text}
-            dhcp_ipv6_check_box=${check_box_disabled}
         fi
     else
         dhcp_status="Disabled"
         dhcp_heatmap=${blue_text}
         dhcp_check_box=${check_box_disabled}
+        dhcp_range="N/A"
 
-        # Display the gateway address if DHCP is disabled
-        GATEWAY="$(GetPADDValue iface.v4.gw_addr | head -n 1)"
-        dhcp_info=" Router:   ${GATEWAY}"
         dhcp_ipv6_status="N/A"
+        dhcp_range_heatmap=${yellow_text}
         dhcp_ipv6_heatmap=${yellow_text}
-        dhcp_ipv6_check_box=${check_box_question}
     fi
 
     # Get hostname
@@ -1022,7 +1027,7 @@ PrintDashboard() {
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK ============${reset_text}"
         moveXOffset; printf "%s${clear_line}\n" " Hst: ${pi_hostname}"
         moveXOffset; printf "%s${clear_line}\n" " IP:  ${pi_ip4_addr}"
-        moveXOffset; printf "%s${clear_line}\n" " DHCP ${dhcp_check_box} IPv6 ${dhcp_ipv6_check_box}"
+        moveXOffset; printf "%s${clear_line}\n" " IPv6 ${ipv6_check_box} DHCP ${dhcp_check_box}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}CPU ================${reset_text}"
         moveXOffset; printf "%s${clear_line}" " [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
     elif [ "$1" = "nano" ]; then
@@ -1035,7 +1040,7 @@ PrintDashboard() {
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK ================${reset_text}"
         moveXOffset; printf "%s${clear_line}\n" " Host: ${pi_hostname}"
         moveXOffset; printf "%s${clear_line}\n" " IP:   ${pi_ip4_addr}"
-        moveXOffset; printf "%s${clear_line}\n" " DHCP: ${dhcp_check_box}    IPv6: ${dhcp_ipv6_check_box}"
+        moveXOffset; printf "%s${clear_line}\n" " IPv6: ${ipv6_check_box}    DHCP: ${dhcp_check_box}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}SYSTEM =================${reset_text}"
         moveXOffset; printf "%s${clear_line}\n" " Up:  ${system_uptime}"
         moveXOffset; printf "%s${clear_line}"  " CPU: [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
@@ -1044,7 +1049,7 @@ PrintDashboard() {
         moveXOffset; printf "%s${clear_line}\n" "µ${padd_text}     ${mini_status}"
         moveXOffset; printf "%s${clear_line}\n" ""
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}PI-HOLE ======================${reset_text}"
-        moveXOffset; printf "%s${clear_line}\n" " DNS:  ${dns_check_box}      FTL:  ${ftl_check_box}"
+        moveXOffset; printf "%s${clear_line}\n" " DNS:  ${dns_check_box}        FTL:  ${ftl_check_box}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}STATS ========================${reset_text}"
         moveXOffset; printf "%s${clear_line}\n" " Blckng:  ${domains_being_blocked} domains"
         moveXOffset; printf "%s${clear_line}\n" " Piholed: [${ads_blocked_bar}] ${ads_percentage_today}%"
@@ -1052,7 +1057,7 @@ PrintDashboard() {
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK ======================${reset_text}"
         moveXOffset; printf "%s${clear_line}\n" " Host:    ${full_hostname}"
         moveXOffset; printf "%s${clear_line}\n" " IP:      ${pi_ip4_addr}"
-        moveXOffset; printf "%s${clear_line}\n" " DHCP:    ${dhcp_check_box}     IPv6:  ${dhcp_ipv6_check_box}"
+        moveXOffset; printf "%s${clear_line}\n" " IPv6: ${ipv6_check_box}       DHCP:  ${dhcp_check_box}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}SYSTEM =======================${reset_text}"
         moveXOffset; printf "%s${clear_line}\n" " Uptime:  ${system_uptime}"
         moveXOffset; printf "%s${clear_line}\n" " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
@@ -1068,16 +1073,12 @@ PrintDashboard() {
         moveXOffset; printf " %-9s[%-20s] %-5s${clear_line}\n" "Piholed:" "${ads_blocked_bar}" "${ads_percentage_today}%"
         moveXOffset; printf " %-9s%-29s${clear_line}\n" "Piholed:" "${ads_blocked_today} out of ${dns_queries_today}"
         moveXOffset; printf " %-9s%-29s${clear_line}\n" "Latest:" "${latest_blocked}"
-        if [ "${DHCP_ACTIVE}" != "true" ]; then
-            moveXOffset; printf " %-9s%-29s${clear_line}\n" "Top Ad:" "${top_blocked}"
-        fi
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK ================================${reset_text}"
         moveXOffset; printf " %-9s%-16s%-5s%-9s${clear_line}\n" "Host:" "${full_hostname}" "DNS:" "${dns_information}"
         moveXOffset; printf " %-9s%s${clear_line}\n" "IP:" "${pi_ip4_addr} (${iface_name})"
+        moveXOffset; printf " %-9s${ipv6_heatmap}%-10s${reset_text} %-8s${dhcp_heatmap}%-10s${reset_text}${clear_line}\n" "IPv6:" "${ipv6_status}" "DHCP:" "${dhcp_status}"
+
         moveXOffset; printf " %-9s%-4s%-12s%-4s%-5s${clear_line}\n" "Traffic:" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
-        if [ "${DHCP_ACTIVE}" = "true" ]; then
-            moveXOffset; printf " %-9s${dhcp_heatmap}%-10s${reset_text} %-9s${dhcp_ipv6_heatmap}%-10s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
-        fi
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}SYSTEM =================================${reset_text}"
         moveXOffset; printf " %-9s%-29s${clear_line}\n" "Uptime:" "${system_uptime}"
         moveXOffset; printf "%s${clear_line}\n" " Load:    [${cpu_load_1_heatmap}${cpu_bar}${reset_text}] ${cpu_percent}%"
@@ -1094,18 +1095,12 @@ PrintDashboard() {
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Pi-holed:" "${ads_blocked_today} out of ${dns_queries_today}"
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Latest:" "${latest_blocked}"
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Top Ad:" "${top_blocked}"
-        if [ "${DHCP_ACTIVE}" != "true" ]; then
-            moveXOffset; printf " %-10s%-39s${clear_line}\n" "Top Dmn:" "${top_domain}"
-            moveXOffset; printf " %-10s%-39s${clear_line}\n" "Top Clnt:" "${top_client}"
-        fi
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK =============================================${reset_text}"
         moveXOffset; printf " %-10s%-16s %-8s%-16s${clear_line}\n" "Hostname:" "${full_hostname}" "IP:  " "${pi_ip4_addr}"
         moveXOffset; printf " %-10s%-16s %-4s%-7s %-4s%-5s${clear_line}\n" "Interfce:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
         moveXOffset; printf " %-10s%-16s %-8s${dnssec_heatmap}%-16s${reset_text}${clear_line}\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_status}"
-        if [ "${DHCP_ACTIVE}" = "true" ]; then
-            moveXOffset; printf " %-10s${dhcp_heatmap}%-16s${reset_text} %-8s${dhcp_ipv6_heatmap}%-10s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
-            moveXOffset; printf "%s${clear_line}\n" "${dhcp_info}"
-        fi
+        moveXOffset; printf " %-10s%s${clear_line}\n" "IPv6:" "${pi_ip6_addr}"
+        moveXOffset; printf " %-10s%-15s%-4s${dhcp_range_heatmap}%-36s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_check_box}" "Rng" "${dhcp_range}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}SYSTEM ==============================================${reset_text}"
         moveXOffset; printf " %-10s%-29s${clear_line}\n" "Uptime:" "${system_uptime}"
         moveXOffset; printf " %-10s${temp_heatmap}%-17s${reset_text} %-8s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}${clear_line}\n" "CPU Temp:" "${temperature}" "Load:" "${cpu_load_1}" "${cpu_load_5}" "${cpu_load_15}"
@@ -1131,18 +1126,12 @@ PrintDashboard() {
         moveXOffset; printf " %-10s%-49s${clear_line}\n" "Pi-holed:" "${ads_blocked_today} out of ${dns_queries_today} queries"
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Latest:" "${latest_blocked}"
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Top Ad:" "${top_blocked}"
-        if [ "${DHCP_ACTIVE}" != "true" ]; then
-            moveXOffset; printf " %-10s%-39s${clear_line}\n" "Top Dmn:" "${top_domain}"
-            moveXOffset; printf " %-10s%-39s${clear_line}\n" "Top Clnt:" "${top_client}"
-        fi
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}NETWORK ====================================================${reset_text}"
-        moveXOffset; printf " %-10s%-15s %-4s%-17s%-6s%s${clear_line}\n" "Hostname:" "${full_hostname}" "IP:" "${pi_ip4_addr}" "IPv6:" "${ipv6_check_box}"
+        moveXOffset; printf " %-10s%-15s %-4s%-17s${clear_line}\n" "Hostname:" "${full_hostname}" "IP:" "${pi_ip4_addr}"
         moveXOffset; printf " %-10s%-15s %-4s%-17s%-4s%s${clear_line}\n" "Interfce:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
+        moveXOffset; printf " %-10s%s${clear_line}\n" "IPv6:" "${pi_ip6_addr}"
         moveXOffset; printf " %-10s%-15s %-10s${dnssec_heatmap}%-19s${reset_text}${clear_line}\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_status}"
-        if [ "${DHCP_ACTIVE}" = "true" ]; then
-            moveXOffset; printf " %-10s${dhcp_heatmap}%-15s${reset_text} %-10s${dhcp_ipv6_heatmap}%-19s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_status}" "IPv6:" ${dhcp_ipv6_status}
-            moveXOffset; printf "%s${clear_line}\n" "${dhcp_info}"
-        fi
+        moveXOffset; printf " %-10s%-16s%-6s${dhcp_range_heatmap}%-36s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_check_box}" "Range" "${dhcp_range}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}SYSTEM =====================================================${reset_text}"
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Uptime:" "${system_uptime}"
         moveXOffset; printf " %-10s${temp_heatmap}%-21s${reset_text}%-10s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}${clear_line}\n" "CPU Temp:" "${temperature}" "CPU Load:" "${cpu_load_1}" "${cpu_load_5}" "${cpu_load_15}"
@@ -1170,7 +1159,7 @@ PrintDashboard() {
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}DNS ==========================DHCP==============================================${reset_text}"
         moveXOffset; printf " %-10s%-19s %-6s${dhcp_heatmap}%-19s${reset_text}${clear_line}\n" "Servers:" "${dns_information}" "DHCP:" "${dhcp_status}"
         moveXOffset; printf " %-10s${dnssec_heatmap}%-19s${reset_text} %-10s${dhcp_ipv6_heatmap}%-9s${reset_text}${clear_line}\n" "DNSSEC:" "${dnssec_status}" "IPv6 Spt:" "${dhcp_ipv6_status}"
-        moveXOffset; printf " %-10s${conditional_forwarding_heatmap}%-19s${reset_text}%s${clear_line}\n" "CdFwding:" "${conditional_forwarding_status}" "${dhcp_info}"
+        moveXOffset; printf " %-10s${conditional_forwarding_heatmap}%-20s${reset_text}%-6s${dhcp_range_heatmap}%-36s${reset_text}${clear_line}\n" "CdFwding:" "${conditional_forwarding_status}" "Range" "${dhcp_range}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}SYSTEM =========================================================================${reset_text}"
         moveXOffset; printf " %-10s%-39s${clear_line}\n" "Device:" "${sys_model}"
         moveXOffset; printf " %-10s%-39s %-10s[${memory_heatmap}%-10s${reset_text}] %-6s${clear_line}\n" "Uptime:" "${system_uptime}" "Memory:" "${memory_bar}" "${memory_percent}%"

--- a/padd.sh
+++ b/padd.sh
@@ -1632,6 +1632,10 @@ NormalPADD() {
     # Trap the window resize signal (handle window resize events)
     trap 'TerminalResize' WINCH
 
+
+    # Clear the screen once on startup to remove overflow from the startup routine
+    printf '\033[2J'
+
     while true; do
 
     # Generate output that depends on the terminal size


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Improves the shown IPv6 and DHCP info.

1) On smaller PADD sizes, the IPv6 checkbox showed the IPv6 Router advertisement status instead of the availability of an IPv6 address. I think this was misleading and the presence of IPv6 Router advertisement is less important than IPv6 'availability'
2) Always display if Pi-hole has the DHCP server turned on/off
3) If there was enough space, show the DHCP address range
4) If there was enough space, show one IPv6 address

Additionally

1) Fix the startup sequence when starting in 'mini'
2) Clear the screen once on startup to prevent remains from the startup sequence 
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
