### PR TITLE
Fix IPv4 address indicator

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -527,8 +527,9 @@ GetNetworkInformation() {
     if [ "${pi_ip4_addrs}" -eq 0 ]; then
         # No IPv4 address available
         pi_ip4_addr="N/A"
-    #elif [ "${pi_ip4_addrs}" -eq 1 ]; then
-    #    # One IPv4 address available
+    elif [ "${pi_ip4_addrs}" -eq 1 ]; then
+        # One IPv4 address available
+        : # Do nothing as the address is already set
     else
         # More than one IPv4 address available
         pi_ip4_addr="${pi_ip4_addr}+"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes a small issue, where PADD would show the `+` indicator for 'more then one' IPv4 addresses being available when they are not but exactly one.

There was an `elif` statement commented out, because the relevant address was already set, but nevertheless the statement needed to be checked, otherwise the following `else` would have been triggered.

____
1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
