### PR TITLE
Tweak convertUptime() to not rely on external date

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -1413,8 +1413,12 @@ truncateString() {
 # Converts seconds to days, hours, minutes
 # https://unix.stackexchange.com/a/338844
 convertUptime() {
-    # shellcheck disable=SC2016
-    eval "echo $(date -ud "@$1" +'$((%s/3600/24)) days, %H hours, %M minutes')"
+
+  local D=$(($1/60/60/24))
+  local H=$(($1/60/60%24))
+  local M=$(($1/60%60))
+
+  printf "%d days, %02d hours, %02d minutes" $D $H $M
 }
 
 secretRead() {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

For converting the uptime in seconds to days, hours, minutes we used `date` but used some functions of it are not available on all versions of `date` (see https://github.com/pi-hole/PADD/pull/426).

This PR gets rid of `date` and uses arithmetics to do the conversion instead.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
