### PR TITLE
Fix bump workflow by explicitly using if construct

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -17,7 +17,9 @@ jobs:
           LATEST_TAG=$(gh -R $REPO release list -L 1 | awk '{printf $3}')
           echo "Latest version tag for releases in $REPO is $LATEST_TAG"
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
-          [[ -z ${LATEST_TAG} ]] && echo "Error: LATEST_TAG is empty, aborting" && exit 1
+          # Exit when LATEST_TAG is empty, due to github connection errors
+          if [[ -z "${LATEST_TAG}" ]]; then echo "Error: LATEST_TAG is empty, aborting" && exit 1; fi;
+        shell: bash
 
       - name: Checkout code
         uses: actions/checkout@v4.2.2
@@ -28,14 +30,16 @@ jobs:
         run: |
           LATEST_TAG=${{ env.latest_tag }}
           REMOTE_BRANCH=$(git ls-remote --heads origin "bump_$LATEST_TAG")
-          [[ -z ${REMOTE_BRANCH} ]] && echo "branch_exists=false" >> $GITHUB_ENV || echo "branch_exists=true" >> $GITHUB_ENV
-          [[ -z ${REMOTE_BRANCH} ]] && echo "Remote branch bump_$LATEST_TAG does not exist" || echo "Remote branch bump_$LATEST_TAG already exists"
+          [[ -z "${REMOTE_BRANCH}" ]] && echo "branch_exists=false" >> $GITHUB_ENV || echo "branch_exists=true" >> $GITHUB_ENV
+          [[ -z "${REMOTE_BRANCH}" ]] && echo "Remote branch bump_$LATEST_TAG does not exist" || echo "Remote branch bump_$LATEST_TAG already exists"
+        shell: bash
 
       - name: Get current version
         run: |
           CURRENT_VERSION=$(cat padd.sh | grep '^padd_version=' | cut -d'"' -f 2)
           echo "Current PADD version is $CURRENT_VERSION"
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_ENV
+        shell: bash
 
       - name: Create PR if versions don't match and branch does not exist
         if: (env.current_version != env.latest_tag) && (env.branch_exists == 'false')
@@ -48,3 +52,4 @@ jobs:
           git commit -a -m "Bump version to $LATEST_TAG"
           git push --set-upstream origin "bump_$LATEST_TAG"
           gh pr create -B development -H "bump_$LATEST_TAG" --title "Bump version to ${LATEST_TAG}" --body 'Created by Github action' --label 'Internal'
+        shell: bash


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix the bump workflow, which currently failed always due to syntax error in the `run` statement causing the workflow to exit prematurly, even when `LATEST_TAG` is set.

**How does this PR accomplish the above?:**

Explicitly using an `if` construct in the `run` statement.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
