### PR TITLE
Drop JSON output and allow update command without authentication

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -1503,29 +1503,6 @@ check_dependencies() {
 
 ########################################## MAIN FUNCTIONS ##########################################
 
-OutputJSON() {
-    # Hiding the cursor.
-    # https://vt100.net/docs/vt510-rm/DECTCEM.html
-    printf '\e[?25l'
-    # Traps for graceful shutdown
-    # https://unix.stackexchange.com/a/681201
-    trap CleanExit EXIT
-    trap sig_cleanup INT QUIT TERM
-    # Save current terminal settings (needed for later restore after password prompt)
-    stty_orig=$(stty -g)
-
-    # Test if the authentication endpoint is available
-    TestAPIAvailability
-    # Authenticate with the FTL server
-    printf "%b" "Establishing connection with FTL...\n"
-    LoginAPI
-
-    GetPADDData
-    GetSummaryInformation
-    printf "%b" "{\"domains_being_blocked\":${domains_being_blocked_raw},\"dns_queries_today\":${dns_queries_today_raw},\"ads_blocked_today\":${ads_blocked_today_raw},\"ads_percentage_today\":${ads_percentage_today},\"clients\": ${clients}}"
-    exit 0
-}
-
 ShowVersion() {
     # Hiding the cursor.
     # https://vt100.net/docs/vt510-rm/DECTCEM.html
@@ -1552,10 +1529,10 @@ ShowVersion() {
     fi
     if [ ! "${DOCKER_VERSION}" = "null" ]; then
         # Check for latest Docker version
-        printf "%s${clear_line}\n" "PADD version is ${padd_version} as part of Docker ${docker_version_heatmap}${DOCKER_VERSION}${reset_text} (Latest Docker: ${GITHUB_DOCKER_VERSION})"
+        printf "\n%s${clear_line}\n" "PADD version is ${padd_version} as part of Docker ${docker_version_heatmap}${DOCKER_VERSION}${reset_text} (Latest Docker: ${GITHUB_DOCKER_VERSION})"
         version_info="Docker ${docker_version_heatmap}${DOCKER_VERSION}${reset_text}"
     else
-        printf "%s${clear_line}\n" "PADD version is ${padd_version_heatmap}${padd_version}${reset_text} (Latest: ${padd_version_latest})"
+        printf "\n%s${clear_line}\n" "PADD version is ${padd_version_heatmap}${padd_version}${reset_text} (Latest: ${padd_version_latest})"
     fi
     exit 0
 }
@@ -1828,7 +1805,6 @@ DisplayHelp() {
 :::  --server <DOMAIN|IP>    domain or IP of your Pi-hole (default: localhost)
 :::  --secret <password>     your Pi-hole's password, required to access the API
 :::  --2fa <2fa>             your Pi-hole's 2FA code, if 2FA is enabled
-:::  -j, --json              output stats as JSON formatted string and exit
 :::  -u, --update            update to the latest version
 :::  -v, --version           show PADD version info
 :::  -h, --help              display this help text
@@ -1923,7 +1899,6 @@ main(){
 # Process all options (if present)
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        "-j" | "--json"     ) xOffset=0; showJSON=true;;
         "-u" | "--update"   ) xOffset=0; doUpdate=true;;
         "-h" | "--help"     ) DisplayHelp; exit 0;;
         "-v" | "--version"  ) xOffset=0; versionOnly=true ;;
@@ -1936,10 +1911,6 @@ while [ "$#" -gt 0 ]; do
     esac
     shift
 done
-
-if [ "${showJSON}" = true ]; then
-    OutputJSON
-fi
 
 if [ "${versionOnly}" ]; then
     ShowVersion

--- a/padd.sh
+++ b/padd.sh
@@ -1523,6 +1523,7 @@ OutputJSON() {
     GetPADDData
     GetSummaryInformation
     printf "%b" "{\"domains_being_blocked\":${domains_being_blocked_raw},\"dns_queries_today\":${dns_queries_today_raw},\"ads_blocked_today\":${ads_blocked_today_raw},\"ads_percentage_today\":${ads_percentage_today},\"clients\": ${clients}}"
+    exit 0
 }
 
 ShowVersion() {
@@ -1556,6 +1557,7 @@ ShowVersion() {
     else
         printf "%s${clear_line}\n" "PADD version is ${padd_version_heatmap}${padd_version}${reset_text} (Latest: ${padd_version_latest})"
     fi
+    exit 0
 }
 
 StartupRoutine(){
@@ -1921,10 +1923,10 @@ main(){
 # Process all options (if present)
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        "-j" | "--json"     ) xOffset=0; OutputJSON; exit 0;;
-        "-u" | "--update"   ) Update;;
+        "-j" | "--json"     ) xOffset=0; showJSON=true;;
+        "-u" | "--update"   ) xOffset=0; doUpdate=true;;
         "-h" | "--help"     ) DisplayHelp; exit 0;;
-        "-v" | "--version"  ) xOffset=0; ShowVersion; exit 0;;
+        "-v" | "--version"  ) xOffset=0; versionOnly=true ;;
         "--xoff"            ) xOffset="$2"; xOffOrig="$2"; shift;;
         "--yoff"            ) yOffset="$2"; yOffOrig="$2"; shift;;
         "--server"          ) SERVER="$2"; shift;;
@@ -1934,5 +1936,17 @@ while [ "$#" -gt 0 ]; do
     esac
     shift
 done
+
+if [ "${showJSON}" = true ]; then
+    OutputJSON
+fi
+
+if [ "${versionOnly}" ]; then
+    ShowVersion
+fi
+
+if [ "${doUpdate}" ]; then
+    Update
+fi
 
 main

--- a/padd.sh
+++ b/padd.sh
@@ -871,10 +871,6 @@ GetVersionInformation() {
 }
 
 GetPADDInformation() {
-    # If PADD is running inside docker, immediately return without checking for an update
-    if [ ! "${DOCKER_VERSION}" = "null" ]; then
-        return
-    fi
 
     # PADD version information...
     padd_version_latest="$(curl --connect-timeout 5 --silent https://api.github.com/repos/pi-hole/PADD/releases/latest | grep '"tag_name":' | awk -F \" '{print $4}')"
@@ -1761,31 +1757,8 @@ NormalPADD() {
 }
 
 Update() {
-    # Hiding the cursor.
-    # https://vt100.net/docs/vt510-rm/DECTCEM.html
-    printf '\e[?25l'
-    # Traps for graceful shutdown
-    # https://unix.stackexchange.com/a/681201
-    trap CleanExit EXIT
-    trap sig_cleanup INT QUIT TERM
 
-    # Save current terminal settings (needed for later restore after password prompt)
-    stty_orig=$(stty -g)
-
-    # Test if the authentication endpoint is available
-    TestAPIAvailability
-    # Authenticate with the FTL server
-    printf "%b" "Establishing connection with FTL...\n"
-    LoginAPI
-
-    GetPADDData
-    GetVersionInformation
     GetPADDInformation
-
-    if [ ! "${DOCKER_VERSION}" = "null" ]; then
-        echo "${check_box_info} Update is not supported for Docker"
-        exit 1
-    fi
 
     if [ "${padd_out_of_date_flag}" = "true" ]; then
         echo "${check_box_info} Updating PADD from ${padd_version} to ${padd_version_latest}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

1) Removes the json output functionality. Pi-hole v6 has a new API which will respond with JSON by default. Instead of misusing PADD for some kind of stats output in JSON, users should directly interact with the API
2) Fix the internal update function. It was not ported to v6 so far, esp. it rely on the presence of `/etc/pihole/versions` which does not exist when PADD is run remotely.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
