### PR TITLE
Add option to display PADD only once and exit

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -25,6 +25,9 @@ LastCheckNetworkInformation=$(date +%s)
 # padd_data holds the data returned by FTL's /padd endpoint globally
 padd_data=""
 
+# should PADD run only once?
+runOnce=false
+
 # COLORS
 CSI="$(printf '\033')["  # Control Sequence Introducer
 red_text="${CSI}91m"     # Red
@@ -1709,6 +1712,11 @@ NormalPADD() {
     # Output everything to the screen
     PrintDashboard ${padd_size}
 
+    # Should we only run once?
+    if [ "${runOnce}" = "true" ]; then
+        break
+    fi
+
     # Sleep for 5 seconds
     # sending sleep in the background and wait for it
     # this way the TerminalResize trap can kill the sleep
@@ -1812,6 +1820,7 @@ DisplayHelp() {
 :::  --server <DOMAIN|IP>    domain or IP of your Pi-hole (default: localhost)
 :::  --secret <password>     your Pi-hole's password, required to access the API
 :::  --2fa <2fa>             your Pi-hole's 2FA code, if 2FA is enabled
+:::  --runonce               display output once and exit
 :::  -u, --update            update to the latest version
 :::  -v, --version           show PADD version info
 :::  -h, --help              display this help text
@@ -1909,6 +1918,7 @@ while [ "$#" -gt 0 ]; do
         "-u" | "--update"   ) xOffset=0; doUpdate=true;;
         "-h" | "--help"     ) DisplayHelp; exit 0;;
         "-v" | "--version"  ) xOffset=0; versionOnly=true ;;
+        "--runonce"         ) runOnce=true;;
         "--xoff"            ) xOffset="$2"; xOffOrig="$2"; shift;;
         "--yoff"            ) yOffset="$2"; yOffOrig="$2"; shift;;
         "--server"          ) SERVER="$2"; shift;;

--- a/padd.sh
+++ b/padd.sh
@@ -1683,12 +1683,15 @@ StartupRoutine(){
         fi
     fi
 
-    moveXOffset; printf "%s" "- Starting in "
-    for i in 3 2 1
-    do
-        printf "%s..." "$i"
-        sleep 1
-    done
+    if [ "${runOnce}" = "false" ]; then
+        moveXOffset; printf "%s" "- Starting in "
+        for i in 3 2 1
+        do
+            printf "%s..." "$i"
+            sleep 1
+        done
+    fi
+
 }
 
 NormalPADD() {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

As the title says, add the option `--runonce` to display PADD dashboard once and immediately exit.

Fixes https://github.com/pi-hole/PADD/issues/431

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
