### PR TITLE
fix dhcp display in padd tiny

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -1156,7 +1156,7 @@ PrintDashboard() {
         moveXOffset; printf " %-10s%-16s %-4s%-7s %-4s%-5s${clear_line}\n" "Interfce:" "${iface_name}" "TX:" "${tx_bytes}" "RX:" "${rx_bytes}"
         moveXOffset; printf " %-10s%-16s %-8s${dnssec_heatmap}%-16s${reset_text}${clear_line}\n" "DNS:" "${dns_information}" "DNSSEC:" "${dnssec_status}"
         moveXOffset; printf " %-10s%s${clear_line}\n" "IPv6:" "${pi_ip6_addr}"
-        moveXOffset; printf " %-10s%-15s%-4s${dhcp_range_heatmap}%-36s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_check_box}" "Rng" "${dhcp_range}"
+        moveXOffset; printf " %-10s%-5s %-4s${dhcp_range_heatmap}%-33s${reset_text}${clear_line}\n" "DHCP:" "${dhcp_check_box}" "Rng" "${dhcp_range}"
         moveXOffset; printf "%s${clear_line}\n" "${bold_text}SYSTEM ==============================================${reset_text}"
         moveXOffset; printf " %-10s%-29s${clear_line}\n" "Uptime:" "${system_uptime}"
         moveXOffset; printf " %-10s${temp_heatmap}%-17s${reset_text} %-8s${cpu_load_1_heatmap}%-4s${reset_text}, ${cpu_load_5_heatmap}%-4s${reset_text}, ${cpu_load_15_heatmap}%-4s${reset_text}${clear_line}\n" "CPU Temp:" "${temperature}" "Load:" "${cpu_load_1}" "${cpu_load_5}" "${cpu_load_15}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This PR fixes a regression to PADDtiny introduced in `v4.0.0`. 

The addition of the DHCP status display caused line wrapping, which caused a blank line to appear, which cut off the header information display.

![diff](https://github.com/user-attachments/assets/d9cf35a8-0e6b-48fb-b3ff-88577e72f00d)

**How does this PR accomplish the above?:**

1. Maintains the correct number of lines for the tiny display (53x20)
2. Shows both IPv6 and DHCP status information
3. Keeps the formatting consistent with other display modes

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
7. I have checked that another pull request for this purpose does not exist.
8. I have considered, and confirmed that this submission will be valuable to others.
9. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
10. I give this submission freely, and claim no ownership to its content.

---
- [x ] I have read the above and my PR is ready for review. *Check this box to confirm*
