### PR TITLE
Fix two shellcheck warnings

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -414,7 +414,7 @@ GetSystemInformation() {
 
     # CPU temperature and unit
     cpu_temp_raw=$(GetPADDValue sensors.cpu_temp)
-    if [ $cpu_temp_raw != null ]; then
+    if [ "${cpu_temp_raw}" != null ]; then
         cpu_temp=$(printf "%.1f" "${cpu_temp_raw}")
         temp_unit=$(echo "${padd_data}"  | GetPADDValue sensors.unit)
     fi
@@ -457,7 +457,7 @@ GetSystemInformation() {
     elif [ "${cpu_temp_celsius}" -gt -274 ]; then
         temp_heatmap=${cyan_text}
     else
-        temp_heatmap=${clear_text}
+        temp_heatmap=${reset_text}
     fi
 
     # CPU, load, heatmap
@@ -508,6 +508,7 @@ GetNetworkInformation() {
         dhcp_range_heatmap=${reset_text}
         dhcp_ipv6_status="N/A"
         dhcp_ipv6_heatmap=${reset_text}
+        dhcp_check_box=${check_box_question}
 
         pi_hostname="N/A"
         full_hostname="N/A"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes two shellcheck warnings and adds a forgotten dhcp_status checkbox in case FTL is down.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
