### PR TITLE
Substitute 'null' values returned by FTL for privacy level >1

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -403,6 +403,19 @@ GetSummaryInformation() {
     top_domain_raw=$(GetPADDValue top_domain)
 
     top_client_raw=$(GetPADDValue top_client)
+
+    privacy_level=$(GetPADDValue config.privacy_level)
+
+    # Substitute 'null' values returned by FTL for privacy level >1
+    if [ "${privacy_level}" -ge "1" ]; then
+        top_domain_raw="hidden by privacy level"
+        top_blocked_raw="hidden by privacy level"
+        latest_blocked_raw="hidden by privacy level"
+    fi
+    if [ "${privacy_level}" -ge "2" ]; then
+        top_client_raw="hidden by privacy level"
+    fi
+
 }
 
 GetSystemInformation() {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Substitute 'null' values returned by FTL for privacy level >1

See this discussion: https://github.com/pi-hole/PADD/issues/452
Needs: https://github.com/pi-hole/FTL/pull/2402

![2025-03-31_22-01](https://github.com/user-attachments/assets/9ea1fa4d-4cf6-4b00-b60e-c1929562bd37)


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
