### PR TITLE
Fix API_Port logic

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -103,7 +103,7 @@ padd_logo_3="${bold_text}${green_text}|   ${red_text}/${yellow_text}-${green_tex
 
 TestAPIAvailability() {
 
-    local chaos_api_list authResponse cmdResult digReturnCode authStatus authData
+    local chaos_api_list authResponse cmdResult digReturnCode authStatus authData apiAvailable
 
     # Query the API URLs from FTL using CHAOS TXT
     # The result is a space-separated enumeration of full URLs
@@ -164,7 +164,7 @@ TestAPIAvailability() {
         # Test if http status code was 200 (OK) or 401 (authentication required)
         if [ ! "${authStatus}" = 200 ] && [ ! "${authStatus}" = 401 ]; then
             # API is not available at this port/protocol combination
-            API_PORT=""
+            apiAvailable=false
         else
             # API is available at this URL combination
 
@@ -176,6 +176,7 @@ TestAPIAvailability() {
             # Check if 2FA is required
             needTOTP=$(echo "${authData}"| jq --raw-output .session.totp 2>/dev/null)
 
+            apiAvailable=true
             break
         fi
 
@@ -191,9 +192,9 @@ TestAPIAvailability() {
         fi
     done
 
-    # if API_PORT is empty, no working API port was found
-    if [ -n "${API_PORT}" ]; then
-        moveXOffset; echo "API not available at: ${API_URL}"
+    # if apiAvailable is false, no working API was found
+    if [ "${apiAvailable}" = false ]; then
+        moveXOffset; echo "API not available. Please check FTL.log"
         moveXOffset; echo "Exiting."
         exit 1
     fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

PADD backport of https://github.com/pi-hole/pi-hole/pull/6193

 I noticed we had the leftover `API_PORT` which was intended to signal if we found a responding api. The check for emptiness was wrong in the first place (using `-n` instead of `-z`). 

This PR fixes the logic by better naming the variable and explicitly setting it to true/false.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
