### PR TITLE
Invert response code logic

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -162,33 +162,33 @@ TestAPIAvailability() {
         authData=$(printf %s "${authResponse%???}")
 
         # Test if http status code was 200 (OK) or 401 (authentication required)
-        if [ ! "${authStatus}" = 200 ] && [ ! "${authStatus}" = 401 ]; then
-            # API is not available at this port/protocol combination
-            apiAvailable=false
-        else
-            # API is available at this URL combination
+        if [ "${authStatus}" = 200 ]; then
+            # API is available without authentication
+            apiAvailable=true
+            needAuth=false
+            break
 
-            if [ "${authStatus}" = 200 ]; then
-                # API is available without authentication
-                needAuth=false
-            fi
-
+        elif [ "${authStatus}" = 401 ]; then
+            # API is available with authentication
+            apiAvailable=true
+            needAuth=true
             # Check if 2FA is required
             needTOTP=$(echo "${authData}"| jq --raw-output .session.totp 2>/dev/null)
-
-            apiAvailable=true
             break
-        fi
+        else
+            # API is not available at this port/protocol combination
+            apiAvailable=false
 
-        # Remove the first URL from the list
-        local last_api_list
-        last_api_list="${chaos_api_list}"
-        chaos_api_list="${chaos_api_list#* }"
+            # Remove the first URL from the list
+            local last_api_list
+            last_api_list="${chaos_api_list}"
+            chaos_api_list="${chaos_api_list#* }"
 
-        # If the list did not change, we are at the last element
-        if [ "${last_api_list}" = "${chaos_api_list}" ]; then
-            # Remove the last element
-            chaos_api_list=""
+            # If the list did not change, we are at the last element
+            if [ "${last_api_list}" = "${chaos_api_list}" ]; then
+                # Remove the last element
+                chaos_api_list=""
+            fi
         fi
     done
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Reverts the logic for HTTP return code check. Instead of checking if the code is **not** 200 or 401, we now explicitly check for 200 and 401.

This is a PADD backport of 

https://github.com/pi-hole/pi-hole/pull/6193/commits/fc103af050c4253ebe616721ba4708163cfa4c2f

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
