### PR TITLE
Convert values to strings before using join function for jq 1.5 support

### DIFF
--- a/padd.sh
+++ b/padd.sh
@@ -353,6 +353,7 @@ GetPADDData() {
         # Using "paths(scalars | true)" will return null and false values.
         # We also check if the value is exactly `null` and, in this case, return the
         # string "null", as jq would return an empty string for nulls.
+        # 'tostring' is necessary because jq < 1.6 does not convert numbers and bools automatically
         padd_data=$(echo "${response}" | jq -r 'paths(scalars | true) as $p | [[$p | .[] | tostring] | join(".")] + [if getpath($p)!=null then (getpath($p) | tostring) else "null" end] | join("=")' 2>/dev/null)
     fi
 }

--- a/padd.sh
+++ b/padd.sh
@@ -353,7 +353,7 @@ GetPADDData() {
         # Using "paths(scalars | true)" will return null and false values.
         # We also check if the value is exactly `null` and, in this case, return the
         # string "null", as jq would return an empty string for nulls.
-        padd_data=$(echo "${response}" | jq -r 'paths(scalars | true) as $p | [$p | join(".")] + [if getpath($p)!=null then getpath($p) else "null" end] | join("=")' 2>/dev/null)
+        padd_data=$(echo "${response}" | jq -r 'paths(scalars | true) as $p | [[$p | .[] | tostring] | join(".")] + [if getpath($p)!=null then (getpath($p) | tostring) else "null" end] | join("=")' 2>/dev/null)
     fi
 }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes display empty of data from PADD.sh when running on a machine with jq 1.5.

For a while now my RPi 3 hasn't been showing statistics, and I finally dug into it today. By redirecting stdout to a text file, I was able to see some errors being thrown by the script:

```sh
$ ./padd.sh --runonce > padd_output.txt

./padd.sh: 414: [: Illegal number: 
./padd.sh: 419: [: Illegal number: 
./padd.sh: 571: [: Illegal number: 
./padd.sh: 574: [: Illegal number: 
./padd.sh: 585: [: Illegal number: 
./padd.sh: 591: [: Illegal number: 
./padd.sh: 655: [: Illegal number: 
./padd.sh: 1454: ./padd.sh: arithmetic expression: expecting primary: "/60/60/24"
```

The contents of `padd_output.txt` were (colorized and centered, and this output is from a different run than the json included below):
```text
 __      __  __   
|__) /\ |  \|  \     Docker , PADD v4.1.0
|   /--\|__/|__/     [✓] DNS   [✓] FTL   

STATS ==========================================================================
 Blocking: 0 domains           Piholed:  [■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■] 0.0% 
 Clients:                                 0 out of 0 queries          
 Latest:   _dns.resolver.arpa                     
 Top Ad:                                          
 Top Dmn:                                         
 Top Clnt:                                        
FTL ============================================================================
 PID:                CPU Use:  0.0%      Mem. Use: 0.0%     
 DNSCache:  insertions,  deletions,  total entries                              
NETWORK ========================================================================
 Hostname:                    
 Interfce:                 TX: 0.0       RX: 0.0      
 IPv4: +                   IPv6:     +                            
DNS ==========================DHCP==============================================
 Servers:   servers            DHCP: Disabled           
 DNSSEC:   Disabled            IPv6 Spt: N/A      
 CdFwding: Disabled            Range N/A                                 
SYSTEM =========================================================================
 Device:   Container                              
 Uptime:                                           Memory:   [··········] 0.0%  
 CPU Temp: N/A       CPU Load: 0.00, 0.00, 0.00    CPU Load: [··········] 0.0%  

Session successfully deleted.
```

Further investigation (running script with `-x` and poking around) showed the root cause was that `GetPADDData` wasn't able to parse the json correctly:

```sh
$ response='{"recent_blocked":"mask-h2.icloud.com","active_clients":29,"gravity_size":96372,"top_domain":"api.ring.com","top_blocked":"mask.icloud.com","top_client":"hass.djackson.org","blocking":"enabled","queries":{"total":64273,"blocked":9554,"percent_blocked":14.864717483520508},"cache":{"size":10000,"inserted":3658,"evicted":0},"system":{"uptime":2342,"memory":{"ram":{"total":945360,"free":176408,"used":177216,"available":697372,"%used":18.745874587458747},"swap":{"total":102396,"free":102396,"used":0,"%used":0}},"procs":152,"cpu":{"nprocs":4,"%cpu":3.875,"load":{"raw":[0.109375,0.1240234375,0.1474609375],"percent":[2.734375,3.1005859375,3.6865234375]}},"ftl":{"%mem":13.131505012512207,"%cpu":0.600000023841858}},"node_name":"pihole","host_model":"Raspberry Pi 3 Model B Plus Rev 1.3","iface":{"v4":{"addr":"10.10.10.2","rx_bytes":{"value":53.815188,"unit":"M"},"tx_bytes":{"value":8.070791,"unit":"M"},"num_addrs":1,"name":"eth0","gw_addr":"10.10.10.1"},"v6":{"addr":"fe80::6efa:d688:3be7:840a","num_addrs":1,"name":"eth0","gw_addr":null}},"version":{"core":{"local":{"branch":"master","version":"v6.3","hash":"5a23c9c3"},"remote":{"version":"v6.3","hash":"5a23c9c3"}},"web":{"local":{"branch":"master","version":"v6.4","hash":"cd0c392d"},"remote":{"version":"v6.4","hash":"cd0c392d"}},"ftl":{"local":{"hash":"8d1add8d","branch":"master","version":"v6.4.1","date":"2025-11-27 18:02:19 +0000"},"remote":{"version":"v6.4.1","hash":"8d1add8d"}},"docker":{"local":null,"remote":null}},"config":{"dhcp_active":true,"dhcp_start":"10.10.11.1","dhcp_end":"10.10.11.254","dhcp_ipv6":false,"dns_domain":"djackson.org","dns_port":53,"dns_num_upstreams":2,"dns_dnssec":false,"dns_revServer_active":true,"privacy_level":0},"%mem":13.133621215820312,"%cpu":0.600000023841858,"pid":21126,"sensors":{"cpu_temp":65.528,"hot_limit":60,"unit":"C"},"took":0.011656045913696289}'
$ echo "${response}" | jq -r 'paths(scalars | true) as $p | [$p | join(".")] + [if getpath($p)!=null then getpath($p) else "null" end] | join("=")'
recent_blocked=mask-h2.icloud.com
jq: error (at <stdin>:1): string ("=") and number (29) cannot be added
```

Unlike my really old version of jq, both PADD and pi-hole are fully up-to-date:

```
$ ./padd.sh -v
PADD version is v4.1.0 (Latest: v4.1.0)

$ pihole -v
Core version is v6.3 (Latest: v6.3)
Web version is v6.4 (Latest: v6.4)
FTL version is v6.4.1 (Latest: v6.4.1)

$ jq --version
jq-1.5-1-a5b5cbe
```


**How does this PR accomplish the above?:**

Fixes the issue by converting json keys and values to strings using `tostring` before calling `join()`.

The [jq 1.6 documentation](https://jqlang.org/manual/v1.6/#join) for `join` added this text when compared to the docs for v1.5:

> Numbers and booleans in the input are converted to strings. Null values are treated as empty strings. Arrays and objects in the input are not supported.

I haven't done much with jq, so it took some trial and error to get my proposed fix. There might be a more elegant way to do it. Or, maybe you would prefer to require jq >= 1.6, which would be fine. 

I've tested the one-liner in a terminal with jq 1.8 on a different machine, and as far as I can tell, my changed version continues to work correctly.

I did not (yet?) change the comment describing the `jq` invocation in `GetPADDData`, but maybe it should be.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
